### PR TITLE
feat: support keyword token in the model fields

### DIFF
--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -1,4 +1,4 @@
-import { createToken, Lexer } from 'chevrotain';
+import {createToken, Lexer, IMultiModeLexerDefinition} from 'chevrotain';
 
 export const Identifier = createToken({
   name: 'Identifier',
@@ -7,22 +7,22 @@ export const Identifier = createToken({
 export const Datasource = createToken({
   name: 'Datasource',
   pattern: /datasource/,
-  longer_alt: Identifier,
+  push_mode: 'block'
 });
 export const Generator = createToken({
   name: 'Generator',
   pattern: /generator/,
-  longer_alt: Identifier,
+  push_mode: 'block'
 });
 export const Model = createToken({
   name: 'Model',
   pattern: /model/,
-  longer_alt: Identifier,
+  push_mode: 'block'
 });
 export const Enum = createToken({
   name: 'Enum',
   pattern: /enum/,
-  longer_alt: Identifier,
+  push_mode: 'block'
 });
 export const True = createToken({
   name: 'True',
@@ -94,6 +94,7 @@ export const RCurly = createToken({
   name: 'RCurly',
   pattern: /}/,
   label: "'}'",
+  pop_mode:true
 });
 export const LRound = createToken({
   name: 'LRound',
@@ -150,36 +151,49 @@ export const LineBreak = createToken({
   label: 'LineBreak',
 });
 
-export const allTokens = [
+const naTokens = [
   Comment,
   DocComment,
   LineComment,
   LineBreak,
   WhiteSpace,
-  Attribute,
-  ModelAttribute,
-  FieldAttribute,
-  Dot,
-  QuestionMark,
-  Array,
-  LCurly,
-  RCurly,
-  LSquare,
-  RSquare,
-  LRound,
-  RRound,
-  Comma,
-  Colon,
-  Equals,
-  True,
-  False,
-  Null,
-  Datasource,
-  Generator,
-  Model,
-  Enum,
-  StringLiteral,
-  NumberLiteral,
-  Identifier,
-];
-export const PrismaLexer = new Lexer(allTokens);
+]
+
+export const multiModeTokens: IMultiModeLexerDefinition = {
+  modes: {
+    global: [
+      ...naTokens,
+      Datasource,
+      Generator,
+      Model,
+      Enum
+    ],
+    block: [
+      ...naTokens,
+      Attribute,
+      ModelAttribute,
+      FieldAttribute,
+      Dot,
+      QuestionMark,
+      Array,
+      LCurly,
+      RCurly,
+      LSquare,
+      RSquare,
+      LRound,
+      RRound,
+      Comma,
+      Colon,
+      Equals,
+      True,
+      False,
+      Null,
+      StringLiteral,
+      NumberLiteral,
+      Identifier,
+    ]
+  },
+  defaultMode: 'global'
+}
+
+export const PrismaLexer = new Lexer(multiModeTokens);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3,7 +3,7 @@ import * as lexer from './lexer';
 
 export class PrismaParser extends CstParser {
   constructor() {
-    super(lexer.allTokens);
+    super(lexer.multiModeTokens);
     this.performSelfAnalysis();
   }
 

--- a/test/__snapshots__/getSchema.test.ts.snap
+++ b/test/__snapshots__/getSchema.test.ts.snap
@@ -6561,6 +6561,382 @@ exports[`getSchema parse atena-server.prisma 1`] = `
 }"
 `;
 
+exports[`getSchema parse example.prisma 1`] = `
+"{
+  \\"type\\": \\"schema\\",
+  \\"list\\": [
+    {
+      \\"type\\": \\"comment\\",
+      \\"text\\": \\"// https://www.prisma.io/docs/concepts/components/prisma-schema\\"
+    },
+    {
+      \\"type\\": \\"comment\\",
+      \\"text\\": \\"// added some fields to test keyword ambiguous\\"
+    },
+    {
+      \\"type\\": \\"break\\"
+    },
+    {
+      \\"type\\": \\"datasource\\",
+      \\"name\\": \\"db\\",
+      \\"assignments\\": [
+        {
+          \\"type\\": \\"assignment\\",
+          \\"key\\": \\"url\\",
+          \\"value\\": {
+            \\"type\\": \\"function\\",
+            \\"name\\": \\"env\\",
+            \\"params\\": [
+              \\"\\\\\\"DATABASE_URL\\\\\\"\\"
+            ]
+          }
+        },
+        {
+          \\"type\\": \\"assignment\\",
+          \\"key\\": \\"provider\\",
+          \\"value\\": \\"\\\\\\"postgresql\\\\\\"\\"
+        }
+      ]
+    },
+    {
+      \\"type\\": \\"break\\"
+    },
+    {
+      \\"type\\": \\"generator\\",
+      \\"name\\": \\"client\\",
+      \\"assignments\\": [
+        {
+          \\"type\\": \\"assignment\\",
+          \\"key\\": \\"provider\\",
+          \\"value\\": \\"\\\\\\"prisma-client-js\\\\\\"\\"
+        }
+      ]
+    },
+    {
+      \\"type\\": \\"break\\"
+    },
+    {
+      \\"type\\": \\"model\\",
+      \\"name\\": \\"User\\",
+      \\"properties\\": [
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"id\\",
+          \\"fieldType\\": \\"Int\\",
+          \\"array\\": false,
+          \\"optional\\": false,
+          \\"attributes\\": [
+            {
+              \\"type\\": \\"attribute\\",
+              \\"name\\": \\"id\\",
+              \\"kind\\": \\"field\\"
+            },
+            {
+              \\"type\\": \\"attribute\\",
+              \\"name\\": \\"default\\",
+              \\"kind\\": \\"field\\",
+              \\"args\\": [
+                {
+                  \\"type\\": \\"attributeArgument\\",
+                  \\"value\\": {
+                    \\"type\\": \\"function\\",
+                    \\"name\\": \\"autoincrement\\"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"createdAt\\",
+          \\"fieldType\\": \\"DateTime\\",
+          \\"array\\": false,
+          \\"optional\\": false,
+          \\"attributes\\": [
+            {
+              \\"type\\": \\"attribute\\",
+              \\"name\\": \\"default\\",
+              \\"kind\\": \\"field\\",
+              \\"args\\": [
+                {
+                  \\"type\\": \\"attributeArgument\\",
+                  \\"value\\": {
+                    \\"type\\": \\"function\\",
+                    \\"name\\": \\"now\\"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"email\\",
+          \\"fieldType\\": \\"String\\",
+          \\"array\\": false,
+          \\"optional\\": false,
+          \\"attributes\\": [
+            {
+              \\"type\\": \\"attribute\\",
+              \\"name\\": \\"unique\\",
+              \\"kind\\": \\"field\\"
+            }
+          ]
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"name\\",
+          \\"fieldType\\": \\"String\\",
+          \\"array\\": false,
+          \\"optional\\": true
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"role\\",
+          \\"fieldType\\": \\"Role\\",
+          \\"array\\": false,
+          \\"optional\\": false,
+          \\"attributes\\": [
+            {
+              \\"type\\": \\"attribute\\",
+              \\"name\\": \\"default\\",
+              \\"kind\\": \\"field\\",
+              \\"args\\": [
+                {
+                  \\"type\\": \\"attributeArgument\\",
+                  \\"value\\": \\"USER\\"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"posts\\",
+          \\"fieldType\\": \\"Post\\",
+          \\"array\\": true,
+          \\"optional\\": false
+        }
+      ]
+    },
+    {
+      \\"type\\": \\"break\\"
+    },
+    {
+      \\"type\\": \\"model\\",
+      \\"name\\": \\"Post\\",
+      \\"properties\\": [
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"id\\",
+          \\"fieldType\\": \\"Int\\",
+          \\"array\\": false,
+          \\"optional\\": false,
+          \\"attributes\\": [
+            {
+              \\"type\\": \\"attribute\\",
+              \\"name\\": \\"id\\",
+              \\"kind\\": \\"field\\"
+            },
+            {
+              \\"type\\": \\"attribute\\",
+              \\"name\\": \\"default\\",
+              \\"kind\\": \\"field\\",
+              \\"args\\": [
+                {
+                  \\"type\\": \\"attributeArgument\\",
+                  \\"value\\": {
+                    \\"type\\": \\"function\\",
+                    \\"name\\": \\"autoincrement\\"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"createdAt\\",
+          \\"fieldType\\": \\"DateTime\\",
+          \\"array\\": false,
+          \\"optional\\": false,
+          \\"attributes\\": [
+            {
+              \\"type\\": \\"attribute\\",
+              \\"name\\": \\"default\\",
+              \\"kind\\": \\"field\\",
+              \\"args\\": [
+                {
+                  \\"type\\": \\"attributeArgument\\",
+                  \\"value\\": {
+                    \\"type\\": \\"function\\",
+                    \\"name\\": \\"now\\"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"updatedAt\\",
+          \\"fieldType\\": \\"DateTime\\",
+          \\"array\\": false,
+          \\"optional\\": false,
+          \\"attributes\\": [
+            {
+              \\"type\\": \\"attribute\\",
+              \\"name\\": \\"updatedAt\\",
+              \\"kind\\": \\"field\\"
+            }
+          ]
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"published\\",
+          \\"fieldType\\": \\"Boolean\\",
+          \\"array\\": false,
+          \\"optional\\": false,
+          \\"attributes\\": [
+            {
+              \\"type\\": \\"attribute\\",
+              \\"name\\": \\"default\\",
+              \\"kind\\": \\"field\\",
+              \\"args\\": [
+                {
+                  \\"type\\": \\"attributeArgument\\",
+                  \\"value\\": \\"false\\"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"title\\",
+          \\"fieldType\\": \\"String\\",
+          \\"array\\": false,
+          \\"optional\\": false,
+          \\"attributes\\": [
+            {
+              \\"type\\": \\"attribute\\",
+              \\"name\\": \\"VarChar\\",
+              \\"kind\\": \\"field\\",
+              \\"group\\": \\"db\\",
+              \\"args\\": [
+                {
+                  \\"type\\": \\"attributeArgument\\",
+                  \\"value\\": \\"255\\"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"author\\",
+          \\"fieldType\\": \\"User\\",
+          \\"array\\": false,
+          \\"optional\\": true,
+          \\"attributes\\": [
+            {
+              \\"type\\": \\"attribute\\",
+              \\"name\\": \\"relation\\",
+              \\"kind\\": \\"field\\",
+              \\"args\\": [
+                {
+                  \\"type\\": \\"attributeArgument\\",
+                  \\"value\\": {
+                    \\"type\\": \\"keyValue\\",
+                    \\"key\\": \\"fields\\",
+                    \\"value\\": {
+                      \\"type\\": \\"array\\",
+                      \\"args\\": [
+                        \\"authorId\\"
+                      ]
+                    }
+                  }
+                },
+                {
+                  \\"type\\": \\"attributeArgument\\",
+                  \\"value\\": {
+                    \\"type\\": \\"keyValue\\",
+                    \\"key\\": \\"references\\",
+                    \\"value\\": {
+                      \\"type\\": \\"array\\",
+                      \\"args\\": [
+                        \\"id\\"
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"authorId\\",
+          \\"fieldType\\": \\"Int\\",
+          \\"array\\": false,
+          \\"optional\\": true
+        },
+        {
+          \\"type\\": \\"comment\\",
+          \\"text\\": \\"// keyword test\\"
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"model\\",
+          \\"fieldType\\": \\"String\\",
+          \\"array\\": false,
+          \\"optional\\": false
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"generator\\",
+          \\"fieldType\\": \\"String\\",
+          \\"array\\": false,
+          \\"optional\\": false
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"datasource\\",
+          \\"fieldType\\": \\"String\\",
+          \\"array\\": false,
+          \\"optional\\": false
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"enum\\",
+          \\"fieldType\\": \\"String\\",
+          \\"array\\": false,
+          \\"optional\\": false
+        }
+      ]
+    },
+    {
+      \\"type\\": \\"break\\"
+    },
+    {
+      \\"type\\": \\"enum\\",
+      \\"name\\": \\"Role\\",
+      \\"enumerators\\": [
+        {
+          \\"type\\": \\"enumerator\\",
+          \\"name\\": \\"USER\\"
+        },
+        {
+          \\"type\\": \\"enumerator\\",
+          \\"name\\": \\"ADMIN\\"
+        }
+      ]
+    }
+  ]
+}"
+`;
+
 exports[`getSchema parse redwood.prisma 1`] = `
 "{
   \\"type\\": \\"schema\\",

--- a/test/__snapshots__/printSchema.test.ts.snap
+++ b/test/__snapshots__/printSchema.test.ts.snap
@@ -555,6 +555,50 @@ model AccountabilityData {
 "
 `;
 
+exports[`printSchema print example.prisma 1`] = `
+"// https://www.prisma.io/docs/concepts/components/prisma-schema
+// added some fields to test keyword ambiguous
+
+datasource db {
+  url      = env(\\"DATABASE_URL\\")
+  provider = \\"postgresql\\"
+}
+
+generator client {
+  provider = \\"prisma-client-js\\"
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now())
+  email     String   @unique
+  name      String?
+  role      Role     @default(USER)
+  posts     Post[]
+}
+
+model Post {
+  id         Int      @id @default(autoincrement())
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+  published  Boolean  @default(false)
+  title      String   @db.VarChar(255)
+  author     User?    @relation(fields: [authorId], references: [id])
+  authorId   Int?
+  // keyword test
+  model      String
+  generator  String
+  datasource String
+  enum       String
+}
+
+enum Role {
+  USER
+  ADMIN
+}
+"
+`;
+
 exports[`printSchema print redwood.prisma 1`] = `
 "
 datasource DS {

--- a/test/fixtures/example.prisma
+++ b/test/fixtures/example.prisma
@@ -1,0 +1,40 @@
+// https://www.prisma.io/docs/concepts/components/prisma-schema
+// added some fields to test keyword ambiguous
+
+datasource db {
+  url      = env("DATABASE_URL")
+  provider = "postgresql"
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now())
+  email     String   @unique
+  name      String?
+  role      Role     @default(USER)
+  posts     Post[]
+}
+
+model Post {
+  id         Int      @id @default(autoincrement())
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+  published  Boolean  @default(false)
+  title      String   @db.VarChar(255)
+  author     User?    @relation(fields: [authorId], references: [id])
+  authorId   Int?
+  // keyword test
+  model      String
+  generator  String
+  datasource String
+  enum       String
+}
+
+enum Role {
+  USER
+  ADMIN
+}


### PR DESCRIPTION
This should fix #5 .
Instead of using the `longer_alt` to decide the token, I use a multiple mode tokens to decide the tokens and exit the mode by `}`. So far it works and passed all the tests.
Let me know if you want to change anything.
Cheers
