### PR TITLE
PrismaSchemaBuilder API

### DIFF
--- a/src/PrismaSchemaBuilder.ts
+++ b/src/PrismaSchemaBuilder.ts
@@ -1,0 +1,444 @@
+import * as schema from './getSchema';
+import { PrintOptions, printSchema } from './printSchema';
+
+/** Returns the function type Original with its return type changed to NewReturn. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ReplaceReturnType<Original extends (...args: any) => any, NewReturn> = (
+  ...a: Parameters<Original>
+) => NewReturn;
+
+/**
+ * Methods with return values that do not propagate the builder should not have
+ * their return value modified by the type replacement system below
+ * */
+type ExtractKeys = 'getSchema' | 'getSubject' | 'getParent' | 'print';
+
+/** These keys preserve the return value context that they were given */
+type NeutralKeys = 'break' | 'comment' | 'attribute' | 'enumerator';
+
+/** Keys allowed when you call .datasource() or .generator() */
+type DatasourceOrGeneratorKeys = 'assignment';
+
+/** Keys allowed when you call .enum("name") */
+type EnumKeys = 'enumerator';
+
+/** Keys allowed when you call .field("name") */
+type FieldKeys = 'attribute';
+
+/** Keys allowed when you call .model("name") */
+type ModelKeys = 'blockAttribute' | 'field';
+
+/**
+ * Utility type for making the PrismaSchemaBuilder below readable:
+ * Removes methods from the builder that are prohibited based on the context
+ * the builder is in. For example, you can add fields to a model, but you can't
+ * add fields to an enum or a datasource.
+ */
+type PrismaSchemaSubset<
+  Universe extends keyof ConcretePrismaSchemaBuilder,
+  Method
+> = ReplaceReturnType<
+  ConcretePrismaSchemaBuilder[Universe],
+  PrismaSchemaBuilder<Exclude<keyof ConcretePrismaSchemaBuilder, Method>>
+>;
+
+/**
+ * The brain of this whole operation: depending on the key of the method name
+ * we receive, filter the available list of method calls the user can make to
+ * prevent them from making invalid calls, such as builder.datasource().field()
+ * */
+type PrismaSchemaBuilder<K extends keyof ConcretePrismaSchemaBuilder> = {
+  [U in K]: U extends ExtractKeys
+    ? ConcretePrismaSchemaBuilder[U]
+    : U extends NeutralKeys
+    ? ConcretePrismaSchemaBuilder[U] //ReplaceReturnType<ConcretePrismaSchemaBuilder[U], PrismaSchemaBuilder<K>>
+    : U extends 'datasource'
+    ? PrismaSchemaSubset<U, 'datasource' | EnumKeys | FieldKeys | ModelKeys>
+    : U extends 'generator'
+    ? PrismaSchemaSubset<U, EnumKeys | FieldKeys | ModelKeys>
+    : U extends 'model'
+    ? PrismaSchemaSubset<U, DatasourceOrGeneratorKeys | EnumKeys | FieldKeys>
+    : U extends 'field'
+    ? PrismaSchemaSubset<U, DatasourceOrGeneratorKeys | EnumKeys>
+    : U extends 'enum'
+    ? PrismaSchemaSubset<U, DatasourceOrGeneratorKeys | ModelKeys | FieldKeys>
+    : PrismaSchemaSubset<
+        U,
+        DatasourceOrGeneratorKeys | EnumKeys | FieldKeys | ModelKeys | 'comment'
+      >;
+};
+
+type Arg =
+  | string
+  | {
+      name: string;
+      function?: Arg[];
+    };
+type Parent = schema.Block | undefined;
+type Subject = schema.Block | schema.Field | undefined;
+
+export class ConcretePrismaSchemaBuilder {
+  private schema: schema.Schema;
+  private _subject: Subject;
+  private _parent: Parent;
+
+  constructor(source = '') {
+    this.schema = schema.getSchema(source);
+  }
+
+  /** Prints the schema out as a source string */
+  print(options: PrintOptions = {}): string {
+    return printSchema(this.schema, options);
+  }
+
+  /** Returns the underlying schema object for more advanced use cases. */
+  getSchema(): schema.Schema {
+    return this.schema;
+  }
+
+  /** Adds or updates a generator block based on the name. */
+  generator(name: string, provider: string): this {
+    const generator: schema.Generator = this.schema.list.reduce<
+      schema.Generator
+    >(
+      (memo, block) =>
+        block.type === 'generator' && block.name === name ? block : memo,
+      {
+        type: 'generator',
+        name,
+        assignments: [
+          { type: 'assignment', key: 'provider', value: `"${provider}"` },
+        ],
+      }
+    );
+
+    this.schema.list.push(generator);
+    this._subject = generator;
+    return this;
+  }
+
+  drop(name: string): this {
+    const index = this.schema.list.findIndex(
+      block => 'name' in block && block.name === name
+    );
+    this.schema.list.splice(index, 1);
+    return this;
+  }
+
+  /** Sets the datasource for the schema. */
+  datasource(provider: string, url: string | { env: string }): this {
+    const datasource: schema.Datasource = {
+      type: 'datasource',
+      name: 'db',
+      assignments: [
+        {
+          type: 'assignment',
+          key: 'url',
+          value:
+            typeof url === 'string'
+              ? `"${url}"`
+              : { type: 'function', name: 'env', params: [`"${url.env}"`] },
+        },
+        { type: 'assignment', key: 'provider', value: provider },
+      ],
+    };
+    const existingIndex = this.schema.list.findIndex(
+      block => block.type === 'datasource'
+    );
+    this.schema.list.splice(
+      existingIndex,
+      existingIndex !== -1 ? 1 : 0,
+      datasource
+    );
+    this._subject = datasource;
+    return this;
+  }
+
+  /** Adds or updates a model based on the name. Can be chained with .field() or .modelAttribute() to add to it. */
+  model(name: string): this {
+    const model: schema.Model = { type: 'model', name, properties: [] };
+    this.schema.list.push(model);
+    this._subject = model;
+    return this;
+  }
+
+  /** Adds or updates an enum based on the name. Can be chained with .enumerator() to add a value to it. */
+  enum(name: string, enumeratorNames: string[] = []): this {
+    const e: schema.Enum = {
+      type: 'enum',
+      name,
+      enumerators: enumeratorNames.map(name => ({ type: 'enumerator', name })),
+    };
+    this.schema.list.push(e);
+    this._subject = e;
+    return this;
+  }
+
+  enumerator(value: string): this {
+    const subject = this.getSubject<schema.Enum>();
+    if (!subject || !('type' in subject) || subject.type !== 'enum') {
+      throw new Error('Subject must be a prisma model!');
+    }
+
+    subject.enumerators.push({ type: 'enumerator', name: value });
+    return this;
+  }
+
+  /**
+   * Returns the current subject, such as a model, field, or enum.
+   * @example
+   * builder.getModel('User').field('firstName').getSubject() // the firstName field
+   * */
+  private getSubject<S extends Subject>(): S {
+    return this._subject as S;
+  }
+
+  /** Returns the parent of the current subject when in a nested context. The parent of a field is its model. */
+  private getParent<S extends Parent = schema.Model>(): S {
+    return this._parent as S;
+  }
+
+  /**
+   * Adds a block-level attribute to the current model.
+   * @example
+   * builder.model('Project')
+   *   .blockAttribute("map", "projects")
+   *   .blockAttribute("unique", ["firstName", "lastName"]) // @@unique([firstName, lastName])
+   * */
+  blockAttribute(
+    name: string,
+    args?: string | string[] | Record<string, schema.Value>
+  ): this {
+    let subject = this.getSubject<schema.Model>();
+    if (!subject || !('type' in subject) || subject.type !== 'model') {
+      const parent = this.getParent<schema.Model>();
+      if (!parent || !('type' in parent) || parent.type !== 'model')
+        throw new Error('Subject must be a prisma model!');
+
+      subject = this._subject = parent;
+    }
+
+    const attributeArgs = ((): schema.AttributeArgument[] => {
+      if (!args) return [] as schema.AttributeArgument[];
+      if (typeof args === 'string')
+        return [{ type: 'attributeArgument', value: `"${args}"` }];
+      if (Array.isArray(args))
+        return [{ type: 'attributeArgument', value: { type: 'array', args } }];
+      return Object.entries(args).map(([key, value]) => ({
+        type: 'attributeArgument',
+        value: { type: 'keyValue', key, value },
+      }));
+    })();
+
+    const property: schema.ModelAttribute = {
+      type: 'attribute',
+      kind: 'model',
+      name,
+      args: attributeArgs,
+    };
+    subject.properties.push(property);
+    return this;
+  }
+
+  /** Adds an attribute to the current field. */
+  attribute<T extends schema.Field>(
+    name: string,
+    args?: Arg[] | Record<string, string[]>
+  ): this {
+    const parent = this.getParent();
+    const subject = this.getSubject<T>();
+    if (!parent || !('type' in parent) || parent.type !== 'model') {
+      throw new Error('Parent must be a prisma model!');
+    }
+
+    if (!subject || !('type' in subject) || subject.type !== 'field') {
+      throw new Error('Subject must be a prisma field!');
+    }
+
+    if (!subject.attributes) subject.attributes = [];
+    const attribute = subject.attributes.reduce<schema.Attribute>(
+      (memo, attr) =>
+        attr.type === 'attribute' && attr.name === name ? attr : memo,
+      {
+        type: 'attribute',
+        kind: 'field',
+        name,
+      }
+    );
+
+    if (Array.isArray(args)) {
+      const mapArg = (arg: Arg): schema.Value | schema.Func => {
+        return typeof arg === 'string'
+          ? arg
+          : {
+              type: 'function',
+              name: arg.name,
+              params: arg.function?.map(mapArg) ?? [],
+            };
+      };
+
+      if (args.length > 0)
+        attribute.args = args.map(arg => ({
+          type: 'attributeArgument',
+          value: mapArg(arg),
+        }));
+    } else if (typeof args === 'object') {
+      attribute.args = Object.entries(args).map(([key, value]) => ({
+        type: 'attributeArgument',
+        value: { type: 'keyValue', key, value: { type: 'array', args: value } },
+      }));
+    }
+
+    if (!subject.attributes.includes(attribute))
+      subject.attributes.push(attribute);
+
+    return this;
+  }
+
+  /** Add an assignment to a generator or datasource */
+  assignment<T extends schema.Generator | schema.Datasource>(
+    key: string,
+    value: string
+  ): this {
+    const subject = this.getSubject<T>();
+    if (
+      !subject ||
+      !('type' in subject) ||
+      !['generator', 'datasource'].includes(subject.type)
+    )
+      throw new Error('Subject must be a prisma generator or datasource!');
+
+    function tap<T>(subject: T, callback: (s: T) => void) {
+      callback(subject);
+      return subject;
+    }
+
+    const assignment = subject.assignments.reduce<schema.Assignment>(
+      (memo, assignment) =>
+        assignment.type === 'assignment' && assignment.key === key
+          ? tap(assignment, a => {
+              a.value = `"${value}"`;
+            })
+          : memo,
+      {
+        type: 'assignment',
+        key,
+        value: `"${value}"`,
+      }
+    );
+
+    if (!subject.assignments.includes(assignment))
+      subject.assignments.push(assignment);
+
+    return this;
+  }
+
+  private blockInsert(statement: schema.Break | schema.Comment): this {
+    let subject = this.getSubject<schema.Block>();
+    const allowed = ['datasource', 'enum', 'generator', 'model'];
+    if (!subject || !('type' in subject) || !allowed.includes(subject.type)) {
+      const parent = this.getParent<schema.Block>();
+      if (!parent || !('type' in parent) || !allowed.includes(parent.type)) {
+        throw new Error('Subject must be a prisma block!');
+      }
+
+      subject = this._subject = parent;
+    }
+
+    switch (subject.type) {
+      case 'datasource': {
+        subject.assignments.push(statement);
+        break;
+      }
+      case 'enum': {
+        subject.enumerators.push(statement);
+        break;
+      }
+      case 'generator': {
+        subject.assignments.push(statement);
+        break;
+      }
+      case 'model': {
+        subject.properties.push(statement);
+        break;
+      }
+    }
+    return this;
+  }
+
+  /** Add a line break */
+  break(): this {
+    const lineBreak: schema.Break = { type: 'break' };
+    return this.blockInsert(lineBreak);
+  }
+
+  /**
+   * Add a comment. Regular comments start with // and do not appear in the
+   * prisma AST. Node comments start with /// and will appear in the AST,
+   * affixed to the node that follows the comment.
+   * */
+  comment(text: string, node = false): this {
+    const comment: schema.Comment = {
+      type: 'comment',
+      text: `//${node ? '/' : ''} ${text}`,
+    };
+    return this.blockInsert(comment);
+  }
+
+  /**
+   * Add a comment to the schema. Regular comments start with // and do not appear in the
+   * prisma AST. Node comments start with /// and will appear in the AST,
+   * affixed to the node that follows the comment.
+   * */
+  schemaComment(text: string, node = false): this {
+    const comment: schema.Comment = {
+      type: 'comment',
+      text: `//${node ? '/' : ''} ${text}`,
+    };
+    this.schema.list.push(comment);
+    return this;
+  }
+
+  /** Add a field to the current model. The field can be customized further with one or more .attribute() calls. */
+  field(name: string, fieldType: string | schema.Func): this {
+    let subject = this.getSubject<schema.Model>();
+    if (!subject || !('type' in subject) || subject.type !== 'model') {
+      const parent = this.getParent<schema.Model>();
+      if (!parent || !('type' in parent) || parent.type !== 'model')
+        throw new Error('Subject must be a prisma model!');
+
+      subject = this._subject = parent;
+    }
+
+    const field: schema.Field = {
+      type: 'field',
+      name,
+      fieldType,
+    };
+    subject.properties.push(field);
+    this._parent = subject;
+    this._subject = field;
+    return this;
+  }
+
+  /**
+   * Returns the current subject, allowing for more advanced ways of
+   * manipulating the schema.
+   * */
+  then<R extends schema.Block>(callback: (subject: R) => R): this {
+    callback(this._subject as R);
+    return this;
+  }
+}
+
+export function createPrismaSchemaBuilder(
+  source?: string
+): PrismaSchemaBuilder<
+  Exclude<
+    keyof ConcretePrismaSchemaBuilder,
+    DatasourceOrGeneratorKeys | EnumKeys | FieldKeys | ModelKeys
+  >
+> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return new ConcretePrismaSchemaBuilder(source) as any;
+}

--- a/src/getSchema.ts
+++ b/src/getSchema.ts
@@ -104,7 +104,7 @@ export type GroupedAttribute = Attribute & { group: string };
 
 export interface AttributeArgument {
   type: 'attributeArgument';
-  value: KeyValue | Value;
+  value: KeyValue | Value | Func;
 }
 
 export interface KeyValue {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './getSchema';
 export * from './printSchema';
+export * from './PrismaSchemaBuilder';

--- a/src/printSchema.ts
+++ b/src/printSchema.ts
@@ -1,9 +1,28 @@
 import * as Types from './getSchema';
 import { EOL } from 'os';
+import { schemaSorter } from './schemaSorter';
 
-export function printSchema(schema: Types.Schema): string {
+export interface PrintOptions {
+  sort?: boolean;
+  locales?: string | string[];
+  sortOrder?: Array<'generator' | 'datasource' | 'model' | 'enum'>;
+}
+
+export function printSchema(
+  schema: Types.Schema,
+  options: PrintOptions = {}
+): string {
+  const { sort = false, locales = undefined, sortOrder = undefined } = options;
+  let blocks = schema.list;
+  if (sort) {
+    // no point in preserving line breaks when re-sorting
+    blocks = schema.list = blocks.filter(block => block.type !== 'break');
+    const sorter = schemaSorter(schema, locales, sortOrder);
+    blocks.sort(sorter);
+  }
+
   return (
-    schema.list
+    blocks
       .map(printBlock)
       .filter(Boolean)
       .join(EOL)

--- a/src/produceSchema.ts
+++ b/src/produceSchema.ts
@@ -1,0 +1,14 @@
+import { PrintOptions } from './printSchema';
+import { createPrismaSchemaBuilder } from './PrismaSchemaBuilder';
+
+type Options = PrintOptions;
+
+export function produceSchema(
+  source: string,
+  producer: (builder: ReturnType<typeof createPrismaSchemaBuilder>) => void,
+  options: Options = {}
+): string {
+  const builder = createPrismaSchemaBuilder(source);
+  producer(builder);
+  return builder.print(options);
+}

--- a/src/schemaSorter.ts
+++ b/src/schemaSorter.ts
@@ -1,0 +1,38 @@
+import { Block, Schema } from './getSchema';
+
+const unsorted = ['break', 'comment'];
+const defaultSortOrder = [
+  'generator',
+  'datasource',
+  'model',
+  'enum',
+  'break',
+  'comment',
+];
+
+export const schemaSorter = (
+  schema: Schema,
+  locales?: string | string[],
+  sortOrder: string[] = defaultSortOrder
+) => (a: Block, b: Block): number => {
+  // Preserve the position of comments and line breaks relative to their
+  // position in the file, since when a re-sort happens it wouldn't be
+  // clear whether a comment should affix to the object above or below it.
+  const aUnsorted = unsorted.indexOf(a.type) !== -1;
+  const bUnsorted = unsorted.indexOf(b.type) !== -1;
+
+  if (aUnsorted !== bUnsorted) {
+    return schema.list.indexOf(a) - schema.list.indexOf(b);
+  }
+
+  if (sortOrder !== defaultSortOrder)
+    sortOrder = sortOrder.concat(defaultSortOrder);
+  const typeIndex = sortOrder.indexOf(a.type) - sortOrder.indexOf(b.type);
+  if (typeIndex !== 0) return typeIndex;
+
+  // Resolve ties using the name of object's name.
+  if ('name' in a && 'name' in b) return a.name.localeCompare(b.name, locales);
+
+  // If all else fails, leave objects in their original position.
+  return 0;
+};

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -10,7 +10,7 @@ export class PrismaVisitor extends BasePrismaVisitor {
   }
 
   schema(ctx: CstNode & { list: CstNode[] }): Types.Schema {
-    const list = ctx.list?.map(item => this.visit([item]));
+    const list = ctx.list?.map(item => this.visit([item])) || [];
     return { type: 'schema', list };
   }
 

--- a/test/PrismaSchemaBuilder.test.ts
+++ b/test/PrismaSchemaBuilder.test.ts
@@ -1,0 +1,328 @@
+import { createPrismaSchemaBuilder } from '../src/PrismaSchemaBuilder';
+import { loadFixture } from './utils';
+
+describe('PrismaSchemaBuilder', () => {
+  it('adds a generator', () => {
+    const builder = createPrismaSchemaBuilder();
+    builder
+      .generator('client', 'prisma-client-js')
+      .assignment('output', 'client.js');
+    expect(builder.print()).toMatchInlineSnapshot(`
+      "
+      generator client {
+        provider = \\"prisma-client-js\\"
+        output   = \\"client.js\\"
+      }
+      "
+    `);
+  });
+
+  it('sets the datasource', () => {
+    const builder = createPrismaSchemaBuilder();
+    builder.datasource('postgresql', { env: 'DATABASE_URL' });
+    expect(builder.print()).toMatchInlineSnapshot(`
+      "
+      datasource db {
+        url      = env(\\"DATABASE_URL\\")
+        provider = postgresql
+      }
+      "
+    `);
+  });
+
+  it('can reset datasource url with assignments', () => {
+    // not really sure why you'd do this, but *shrug*
+    const builder = createPrismaSchemaBuilder();
+    builder
+      .datasource('postgresql', { env: 'DATABASE_URL' })
+      .assignment('url', 'https://database.com');
+    expect(builder.print()).toMatchInlineSnapshot(`
+      "
+      datasource db {
+        url      = \\"https://database.com\\"
+        provider = postgresql
+      }
+      "
+    `);
+  });
+
+  it('adds a model', () => {
+    const builder = createPrismaSchemaBuilder();
+    builder.model('Project').field('name', 'String');
+    expect(builder.print()).toMatchInlineSnapshot(`
+      "
+      model Project {
+        name String
+      }
+      "
+    `);
+  });
+
+  it('removes a model', () => {
+    const builder = createPrismaSchemaBuilder(`
+      datasource db {
+        url = env("DATABASE_URL")
+      }
+
+      model Project {
+        name String
+      }
+    `);
+    builder.drop('Project');
+    expect(builder.print()).toMatchInlineSnapshot(`
+      "
+      datasource db {
+        url = env(\\"DATABASE_URL\\")
+      }
+
+
+      "
+    `);
+  });
+
+  it('removes an enum', () => {
+    const builder = createPrismaSchemaBuilder(`
+    datasource db {
+      url = env("DATABASE_URL")
+    }
+
+    enum Role {
+      MEMBER
+      ADMIN
+    }
+    `);
+
+    builder.drop('Role');
+
+    expect(builder.print()).toMatchInlineSnapshot(`
+      "
+      datasource db {
+        url = env(\\"DATABASE_URL\\")
+      }
+
+
+      "
+    `);
+  });
+
+  it('adds an enum', () => {
+    const builder = createPrismaSchemaBuilder();
+    builder
+      .enum('Role', ['USER', 'ADMIN'])
+      .break()
+      .comment('test')
+      .enumerator('OWNER');
+
+    expect(builder.print()).toMatchInlineSnapshot(`
+      "
+      enum Role {
+        USER
+        ADMIN
+
+        // test
+        OWNER
+      }
+      "
+    `);
+  });
+
+  it('adds a field to an existing model', () => {
+    const builder = createPrismaSchemaBuilder(`
+    model Project {
+      name String
+    }
+    `);
+    builder.model('Project').field('description', 'String');
+    expect(builder.print()).toMatchInlineSnapshot(`
+      "
+      model Project {
+        name String
+      }
+
+      model Project {
+        description String
+      }
+      "
+    `);
+  });
+
+  it('adds a field relation', () => {
+    const builder = createPrismaSchemaBuilder();
+    builder
+      .model('Project')
+      .field('user', 'User')
+      .attribute('relation', { fields: ['clientId'], references: ['id'] });
+    expect(builder.print()).toMatchInlineSnapshot(`
+      "
+      model Project {
+        user User @relation(fields: [clientId], references: [id])
+      }
+      "
+    `);
+  });
+
+  it('adds a map attribute', () => {
+    const builder = createPrismaSchemaBuilder();
+    builder.model('Project').blockAttribute('map', 'projects');
+    expect(builder.print()).toMatchInlineSnapshot(`
+      "
+      model Project {
+        @@map(\\"projects\\")
+      }
+      "
+    `);
+  });
+
+  it('adds an id attribute', () => {
+    const builder = createPrismaSchemaBuilder();
+    builder
+      .model('User')
+      .field('firstName', 'String')
+      .field('lastName', 'String')
+      .blockAttribute('id', ['firstName', 'lastName']);
+    expect(builder.print()).toMatchInlineSnapshot(`
+      "
+      model User {
+        firstName String
+        lastName  String
+        @@id([firstName, lastName])
+      }
+      "
+    `);
+  });
+
+  it('adds a unique attribute', () => {
+    const builder = createPrismaSchemaBuilder();
+    builder
+      .model('Project')
+      .field('code', 'String')
+      .field('client', 'String')
+      .blockAttribute('unique', ['code', 'client']);
+    expect(builder.print()).toMatchInlineSnapshot(`
+      "
+      model Project {
+        code   String
+        client String
+        @@unique([code, client])
+      }
+      "
+    `);
+  });
+
+  it('adds a comment', () => {
+    const builder = createPrismaSchemaBuilder();
+    builder
+      .model('User')
+      .comment('this is the part of the name you say first', true)
+      .field('firstName', 'String')
+      .comment('this is the part of the name you say last', true)
+      .field('lastName', 'String')
+      .break()
+      .comment('this is a random comment')
+      .break();
+
+    expect(builder.print()).toMatchInlineSnapshot(`
+      "
+      model User {
+        /// this is the part of the name you say first
+        firstName String
+        /// this is the part of the name you say last
+        lastName  String
+
+        // this is a random comment
+
+      }
+      "
+    `);
+  });
+
+  it('adds a schema comment', () => {
+    const builder = createPrismaSchemaBuilder();
+    builder
+      .model('Project')
+      .schemaComment('this is a comment')
+      .schemaComment('this is a node comment', true)
+      .model('Node');
+    expect(builder.print()).toMatchInlineSnapshot(`
+      "
+      model Project {
+        
+      }
+      // this is a comment
+      /// this is a node comment
+
+      model Node {
+        
+      }
+      "
+    `);
+  });
+
+  it('prints the schema', async () => {
+    const source = await loadFixture('example.prisma');
+    const result = createPrismaSchemaBuilder(source).print();
+    expect(result).toMatchInlineSnapshot(`
+      "// https://www.prisma.io/docs/concepts/components/prisma-schema
+      // added some fields to test keyword ambiguous
+
+      datasource db {
+        url      = env(\\"DATABASE_URL\\")
+        provider = \\"postgresql\\"
+      }
+
+      generator client {
+        provider = \\"prisma-client-js\\"
+      }
+
+      model User {
+        id        Int       @id @default(autoincrement())
+        createdAt DateTime  @default(now())
+        email     String    @unique
+        name      String?
+        role      Role      @default(USER)
+        posts     Post[]
+        projects  Project[]
+      }
+
+      model Post {
+        id         Int      @id @default(autoincrement())
+        createdAt  DateTime @default(now())
+        updatedAt  DateTime @updatedAt
+        published  Boolean  @default(false)
+        title      String   @db.VarChar(255)
+        author     User?    @relation(fields: [authorId], references: [id])
+        authorId   Int?
+        // keyword test
+        model      String
+        generator  String
+        datasource String
+        enum       String // inline comment
+
+        @@map(\\"posts\\")
+      }
+
+      model Project {
+        client      User     @relation(fields: [clientId], references: [id])
+        clientId    Int
+        projectCode String
+        dueDate     DateTime
+
+        @@id([projectCode])
+        @@unique([clientId, projectCode])
+        @@index([dueDate])
+      }
+
+      model Model {
+        id Int @id
+
+        @@ignore
+      }
+
+      enum Role {
+        USER // basic role
+        ADMIN // more powerful role
+      }
+      "
+    `);
+  });
+});

--- a/test/__snapshots__/getSchema.test.ts.snap
+++ b/test/__snapshots__/getSchema.test.ts.snap
@@ -6717,6 +6717,13 @@ exports[`getSchema parse example.prisma 1`] = `
           \\"fieldType\\": \\"Post\\",
           \\"array\\": true,
           \\"optional\\": false
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"projects\\",
+          \\"fieldType\\": \\"Project\\",
+          \\"array\\": true,
+          \\"optional\\": false
         }
       ]
     },
@@ -6914,6 +6921,175 @@ exports[`getSchema parse example.prisma 1`] = `
           \\"array\\": false,
           \\"optional\\": false,
           \\"comment\\": \\"// inline comment\\"
+        },
+        {
+          \\"type\\": \\"break\\"
+        },
+        {
+          \\"type\\": \\"attribute\\",
+          \\"name\\": \\"map\\",
+          \\"kind\\": \\"model\\",
+          \\"args\\": [
+            {
+              \\"type\\": \\"attributeArgument\\",
+              \\"value\\": \\"\\\\\\"posts\\\\\\"\\"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      \\"type\\": \\"break\\"
+    },
+    {
+      \\"type\\": \\"model\\",
+      \\"name\\": \\"Project\\",
+      \\"properties\\": [
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"client\\",
+          \\"fieldType\\": \\"User\\",
+          \\"array\\": false,
+          \\"optional\\": false,
+          \\"attributes\\": [
+            {
+              \\"type\\": \\"attribute\\",
+              \\"name\\": \\"relation\\",
+              \\"kind\\": \\"field\\",
+              \\"args\\": [
+                {
+                  \\"type\\": \\"attributeArgument\\",
+                  \\"value\\": {
+                    \\"type\\": \\"keyValue\\",
+                    \\"key\\": \\"fields\\",
+                    \\"value\\": {
+                      \\"type\\": \\"array\\",
+                      \\"args\\": [
+                        \\"clientId\\"
+                      ]
+                    }
+                  }
+                },
+                {
+                  \\"type\\": \\"attributeArgument\\",
+                  \\"value\\": {
+                    \\"type\\": \\"keyValue\\",
+                    \\"key\\": \\"references\\",
+                    \\"value\\": {
+                      \\"type\\": \\"array\\",
+                      \\"args\\": [
+                        \\"id\\"
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"clientId\\",
+          \\"fieldType\\": \\"Int\\",
+          \\"array\\": false,
+          \\"optional\\": false
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"projectCode\\",
+          \\"fieldType\\": \\"String\\",
+          \\"array\\": false,
+          \\"optional\\": false
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"dueDate\\",
+          \\"fieldType\\": \\"DateTime\\",
+          \\"array\\": false,
+          \\"optional\\": false
+        },
+        {
+          \\"type\\": \\"break\\"
+        },
+        {
+          \\"type\\": \\"attribute\\",
+          \\"name\\": \\"id\\",
+          \\"kind\\": \\"model\\",
+          \\"args\\": [
+            {
+              \\"type\\": \\"attributeArgument\\",
+              \\"value\\": {
+                \\"type\\": \\"array\\",
+                \\"args\\": [
+                  \\"projectCode\\"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          \\"type\\": \\"attribute\\",
+          \\"name\\": \\"unique\\",
+          \\"kind\\": \\"model\\",
+          \\"args\\": [
+            {
+              \\"type\\": \\"attributeArgument\\",
+              \\"value\\": {
+                \\"type\\": \\"array\\",
+                \\"args\\": [
+                  \\"clientId\\",
+                  \\"projectCode\\"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          \\"type\\": \\"attribute\\",
+          \\"name\\": \\"index\\",
+          \\"kind\\": \\"model\\",
+          \\"args\\": [
+            {
+              \\"type\\": \\"attributeArgument\\",
+              \\"value\\": {
+                \\"type\\": \\"array\\",
+                \\"args\\": [
+                  \\"dueDate\\"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      \\"type\\": \\"break\\"
+    },
+    {
+      \\"type\\": \\"model\\",
+      \\"name\\": \\"Model\\",
+      \\"properties\\": [
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"id\\",
+          \\"fieldType\\": \\"Int\\",
+          \\"array\\": false,
+          \\"optional\\": false,
+          \\"attributes\\": [
+            {
+              \\"type\\": \\"attribute\\",
+              \\"name\\": \\"id\\",
+              \\"kind\\": \\"field\\"
+            }
+          ]
+        },
+        {
+          \\"type\\": \\"break\\"
+        },
+        {
+          \\"type\\": \\"attribute\\",
+          \\"name\\": \\"ignore\\",
+          \\"kind\\": \\"model\\"
         }
       ]
     },
@@ -7581,6 +7757,212 @@ exports[`getSchema parse test.prisma 1`] = `
           \\"name\\": \\"special\\",
           \\"kind\\": \\"model\\",
           \\"group\\": \\"db\\"
+        }
+      ]
+    }
+  ]
+}"
+`;
+
+exports[`getSchema parse unsorted.prisma 1`] = `
+"{
+  \\"type\\": \\"schema\\",
+  \\"list\\": [
+    {
+      \\"type\\": \\"enum\\",
+      \\"name\\": \\"Role\\",
+      \\"enumerators\\": [
+        {
+          \\"type\\": \\"enumerator\\",
+          \\"name\\": \\"ADMIN\\"
+        },
+        {
+          \\"type\\": \\"enumerator\\",
+          \\"name\\": \\"OWNER\\",
+          \\"comment\\": \\"// similar to ADMIN, but can delete the project\\"
+        },
+        {
+          \\"type\\": \\"enumerator\\",
+          \\"name\\": \\"MEMBER\\"
+        },
+        {
+          \\"type\\": \\"enumerator\\",
+          \\"name\\": \\"USER\\",
+          \\"comment\\": \\"// deprecated\\"
+        }
+      ]
+    },
+    {
+      \\"type\\": \\"break\\"
+    },
+    {
+      \\"type\\": \\"datasource\\",
+      \\"name\\": \\"db\\",
+      \\"assignments\\": [
+        {
+          \\"type\\": \\"assignment\\",
+          \\"key\\": \\"url\\",
+          \\"value\\": {
+            \\"type\\": \\"function\\",
+            \\"name\\": \\"env\\",
+            \\"params\\": [
+              \\"\\\\\\"DATABASE_URL\\\\\\"\\"
+            ]
+          }
+        },
+        {
+          \\"type\\": \\"assignment\\",
+          \\"key\\": \\"provider\\",
+          \\"value\\": \\"\\\\\\"postgresql\\\\\\"\\"
+        }
+      ]
+    },
+    {
+      \\"type\\": \\"break\\"
+    },
+    {
+      \\"type\\": \\"comment\\",
+      \\"text\\": \\"// this is a comment\\"
+    },
+    {
+      \\"type\\": \\"model\\",
+      \\"name\\": \\"User\\",
+      \\"properties\\": [
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"id\\",
+          \\"fieldType\\": \\"Int\\",
+          \\"array\\": false,
+          \\"optional\\": false,
+          \\"attributes\\": [
+            {
+              \\"type\\": \\"attribute\\",
+              \\"name\\": \\"id\\",
+              \\"kind\\": \\"field\\"
+            },
+            {
+              \\"type\\": \\"attribute\\",
+              \\"name\\": \\"default\\",
+              \\"kind\\": \\"field\\",
+              \\"args\\": [
+                {
+                  \\"type\\": \\"attributeArgument\\",
+                  \\"value\\": {
+                    \\"type\\": \\"function\\",
+                    \\"name\\": \\"autoincrement\\"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"createdAt\\",
+          \\"fieldType\\": \\"DateTime\\",
+          \\"array\\": false,
+          \\"optional\\": false,
+          \\"attributes\\": [
+            {
+              \\"type\\": \\"attribute\\",
+              \\"name\\": \\"default\\",
+              \\"kind\\": \\"field\\",
+              \\"args\\": [
+                {
+                  \\"type\\": \\"attributeArgument\\",
+                  \\"value\\": {
+                    \\"type\\": \\"function\\",
+                    \\"name\\": \\"now\\"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"email\\",
+          \\"fieldType\\": \\"String\\",
+          \\"array\\": false,
+          \\"optional\\": false,
+          \\"attributes\\": [
+            {
+              \\"type\\": \\"attribute\\",
+              \\"name\\": \\"unique\\",
+              \\"kind\\": \\"field\\"
+            }
+          ]
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"name\\",
+          \\"fieldType\\": \\"String\\",
+          \\"array\\": false,
+          \\"optional\\": true
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"role\\",
+          \\"fieldType\\": \\"Role\\",
+          \\"array\\": false,
+          \\"optional\\": false,
+          \\"attributes\\": [
+            {
+              \\"type\\": \\"attribute\\",
+              \\"name\\": \\"default\\",
+              \\"kind\\": \\"field\\",
+              \\"args\\": [
+                {
+                  \\"type\\": \\"attributeArgument\\",
+                  \\"value\\": \\"MEMBER\\"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      \\"type\\": \\"break\\"
+    },
+    {
+      \\"type\\": \\"generator\\",
+      \\"name\\": \\"client\\",
+      \\"assignments\\": [
+        {
+          \\"type\\": \\"assignment\\",
+          \\"key\\": \\"provider\\",
+          \\"value\\": \\"\\\\\\"prisma-client-js\\\\\\"\\"
+        }
+      ]
+    },
+    {
+      \\"type\\": \\"break\\"
+    },
+    {
+      \\"type\\": \\"model\\",
+      \\"name\\": \\"AppSetting\\",
+      \\"properties\\": [
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"key\\",
+          \\"fieldType\\": \\"String\\",
+          \\"array\\": false,
+          \\"optional\\": false,
+          \\"attributes\\": [
+            {
+              \\"type\\": \\"attribute\\",
+              \\"name\\": \\"id\\",
+              \\"kind\\": \\"field\\"
+            }
+          ]
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"value\\",
+          \\"fieldType\\": \\"Json\\",
+          \\"array\\": false,
+          \\"optional\\": false
         }
       ]
     }

--- a/test/__snapshots__/printSchema.test.ts.snap
+++ b/test/__snapshots__/printSchema.test.ts.snap
@@ -569,12 +569,13 @@ generator client {
 }
 
 model User {
-  id        Int      @id @default(autoincrement())
-  createdAt DateTime @default(now())
-  email     String   @unique
+  id        Int       @id @default(autoincrement())
+  createdAt DateTime  @default(now())
+  email     String    @unique
   name      String?
-  role      Role     @default(USER)
+  role      Role      @default(USER)
   posts     Post[]
+  projects  Project[]
 }
 
 model Post {
@@ -590,6 +591,25 @@ model Post {
   generator  String
   datasource String
   enum       String // inline comment
+
+  @@map(\\"posts\\")
+}
+
+model Project {
+  client      User     @relation(fields: [clientId], references: [id])
+  clientId    Int
+  projectCode String
+  dueDate     DateTime
+
+  @@id([projectCode])
+  @@unique([clientId, projectCode])
+  @@index([dueDate])
+}
+
+model Model {
+  id Int @id
+
+  @@ignore
 }
 
 enum Role {
@@ -688,6 +708,41 @@ enum Role {
 
   @@map(\\"membership_role\\")
   @@db.special
+}
+"
+`;
+
+exports[`printSchema print unsorted.prisma 1`] = `
+"
+enum Role {
+  ADMIN
+  OWNER // similar to ADMIN, but can delete the project
+  MEMBER
+  USER // deprecated
+}
+
+datasource db {
+  url      = env(\\"DATABASE_URL\\")
+  provider = \\"postgresql\\"
+}
+
+// this is a comment
+
+model User {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now())
+  email     String   @unique
+  name      String?
+  role      Role     @default(MEMBER)
+}
+
+generator client {
+  provider = \\"prisma-client-js\\"
+}
+
+model AppSetting {
+  key   String @id
+  value Json
 }
 "
 `;

--- a/test/fixtures/example.prisma
+++ b/test/fixtures/example.prisma
@@ -11,12 +11,13 @@ generator client {
 }
 
 model User {
-  id        Int      @id @default(autoincrement())
-  createdAt DateTime @default(now())
-  email     String   @unique
+  id        Int       @id @default(autoincrement())
+  createdAt DateTime  @default(now())
+  email     String    @unique
   name      String?
-  role      Role     @default(USER)
+  role      Role      @default(USER)
   posts     Post[]
+  projects  Project[]
 }
 
 model Post {
@@ -32,6 +33,25 @@ model Post {
   generator  String
   datasource String
   enum       String // inline comment
+
+  @@map("posts")
+}
+
+model Project {
+  client      User     @relation(fields: [clientId], references: [id])
+  clientId    Int
+  projectCode String
+  dueDate     DateTime
+
+  @@id([projectCode])
+  @@unique([clientId, projectCode])
+  @@index([dueDate])
+}
+
+model Model {
+  id Int @id
+
+  @@ignore
 }
 
 enum Role {

--- a/test/fixtures/unsorted.prisma
+++ b/test/fixtures/unsorted.prisma
@@ -1,0 +1,29 @@
+enum Role {
+  ADMIN
+  OWNER // similar to ADMIN, but can delete the project
+  MEMBER
+  USER // deprecated
+}
+
+datasource db {
+  url      = env("DATABASE_URL")
+  provider = "postgresql"
+}
+
+// this is a comment
+model User {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now())
+  email     String   @unique
+  name      String?
+  role      Role     @default(MEMBER)
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model AppSetting {
+  key   String @id
+  value Json
+}

--- a/test/printSchema.test.ts
+++ b/test/printSchema.test.ts
@@ -21,4 +21,89 @@ model Foo {
     expect(schema).not.toBeUndefined();
     expect(printSchema(schema)).toMatchSnapshot();
   });
+
+  it('re-sorts the schema', async () => {
+    const source = await loadFixture('unsorted.prisma');
+    const schema = getSchema(source);
+    expect(schema).not.toBeUndefined();
+    expect(printSchema(schema, { sort: true, locales: 'en-US' }))
+      .toMatchInlineSnapshot(`
+      "
+      generator client {
+        provider = \\"prisma-client-js\\"
+      }
+
+      datasource db {
+        url      = env(\\"DATABASE_URL\\")
+        provider = \\"postgresql\\"
+      }
+
+      model AppSetting {
+        key   String @id
+        value Json
+      }
+
+      model User {
+        id        Int      @id @default(autoincrement())
+        createdAt DateTime @default(now())
+        email     String   @unique
+        name      String?
+        role      Role     @default(MEMBER)
+      }
+
+      enum Role {
+        ADMIN
+        OWNER // similar to ADMIN, but can delete the project
+        MEMBER
+        USER // deprecated
+      }
+      // this is a comment
+      "
+    `);
+  });
+
+  it('re-sorts the schema with a custom sort order', async () => {
+    const source = await loadFixture('unsorted.prisma');
+    const schema = getSchema(source);
+    expect(schema).not.toBeUndefined();
+    expect(
+      printSchema(schema, {
+        sort: true,
+        locales: 'en-US',
+        sortOrder: ['generator', 'datasource', 'model', 'enum'],
+      })
+    ).toMatchInlineSnapshot(`
+      "
+      generator client {
+        provider = \\"prisma-client-js\\"
+      }
+
+      datasource db {
+        url      = env(\\"DATABASE_URL\\")
+        provider = \\"postgresql\\"
+      }
+
+      model AppSetting {
+        key   String @id
+        value Json
+      }
+
+      model User {
+        id        Int      @id @default(autoincrement())
+        createdAt DateTime @default(now())
+        email     String   @unique
+        name      String?
+        role      Role     @default(MEMBER)
+      }
+
+      enum Role {
+        ADMIN
+        OWNER // similar to ADMIN, but can delete the project
+        MEMBER
+        USER // deprecated
+      }
+      // this is a comment
+      "
+    `);
+  });
 });

--- a/test/produceSchema.test.ts
+++ b/test/produceSchema.test.ts
@@ -1,0 +1,56 @@
+import { produceSchema } from '../src/produceSchema';
+
+describe('produceSchema', () => {
+  it('prints the schema', () => {
+    const result = produceSchema(
+      '',
+      builder => {
+        builder
+          .datasource('postgresql', { env: 'DATABASE_URL' })
+          .generator('client', 'prisma-client-js')
+          .enum('Role', ['USER', 'ADMIN'])
+          .model('User')
+          .field('id', 'Int')
+          .attribute('id')
+          .attribute('default', [{ name: 'autoincrement' }])
+          .field('name', 'String')
+          .attribute('unique')
+          .model('AppSetting')
+          .field('key', 'String')
+          .attribute('id')
+          .field('value', 'Json')
+          .blockAttribute('index', ['key']);
+      },
+      { sort: true }
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      "
+      generator client {
+        provider = \\"prisma-client-js\\"
+      }
+
+      datasource db {
+        url      = env(\\"DATABASE_URL\\")
+        provider = postgresql
+      }
+
+      model AppSetting {
+        key   String @id
+        value Json
+        @@index([key])
+      }
+
+      model User {
+        id   Int    @id @default(autoincrement())
+        name String @unique
+      }
+
+      enum Role {
+        USER
+        ADMIN
+      }
+      "
+    `);
+  });
+});


### PR DESCRIPTION
Supplements the original API with a builder pattern that should make it much easier to perform the usual kinds of changes you would want to make to a prisma schema; adding and updating models, setting generators, sorting the schema, etc.

The original API is still there, but the README has been updated to focus on the new builder pattern. It is built fully with typescript and dynamically adapts to the context you're in, for example: 
```ts
// yes
builder.model('Project').field('projectCode', 'String')
``` 
will add a "projectCode" field to the "Project" model, because the model can be inferred from the context, but
```ts
// no
builder.field("projectCode", "String")
builder.enum("Role").field("projectCode", "String")
```
will both produce TypeScript errors (and runtime errors) because they are trying to add a field without having a model.