### PR TITLE
add support for keyed args in functions

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -35,7 +35,10 @@ export class PrismaParser extends CstParser {
     this.MANY_SEP({
       SEP: lexer.Comma,
       DEF: () => {
-        this.SUBRULE(this.value);
+        this.OR([
+          { ALT: () => this.SUBRULE(this.keyedArg) },
+          { ALT: () => this.SUBRULE(this.value) }
+        ])
       },
     });
     this.CONSUME(lexer.RRound);

--- a/src/printSchema.ts
+++ b/src/printSchema.ts
@@ -188,8 +188,7 @@ function printFieldType(field: Types.Field) {
   if (typeof field.fieldType === 'object') {
     switch (field.fieldType.type) {
       case 'function': {
-        const params = field.fieldType.params.map(printValue);
-        return `${field.fieldType.name}(${params})${suffix}`;
+        return `${printFunction(field.fieldType)}${suffix}`;
       }
       default:
         throw new Error(`Unexpected field type`);
@@ -197,6 +196,11 @@ function printFieldType(field: Types.Field) {
   }
 
   return `${field.fieldType}${suffix}`;
+}
+
+function printFunction(func: Types.Func) {
+  const params = func.params ? func.params.map(printValue) : '';
+  return `${func.name}(${params})`;
 }
 
 function printValue(value: Types.KeyValue | Types.Value): string {
@@ -207,11 +211,9 @@ function printValue(value: Types.KeyValue | Types.Value): string {
           case 'keyValue':
             return `${value.key}: ${printValue(value.value)}`;
           case 'function':
-            return `${value.name}(${
-              value.params ? value.params.map(printValue) : ''
-            })`;
+            return printFunction(value);
           case 'array':
-            return `[${value.args.join(', ')}]`;
+            return `[${value.args.map(printValue).join(', ')}]`;
           default:
             throw new Error(`Unexpected value type`);
         }

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -109,10 +109,12 @@ export class PrismaVisitor extends BasePrismaVisitor {
     return { type: 'attributeArgument', value };
   }
 
-  func(ctx: CstNode & { funcName: [IToken]; value: CstNode[] }): Types.Func {
+  func(ctx: CstNode & { funcName: [IToken]; value: CstNode[]; keyedArg: CstNode[] }): Types.Func {
     const [{ image: name }] = ctx.funcName;
     const params = ctx.value && ctx.value.map(item => this.visit([item]));
-    return { type: 'function', name, params };
+    const keyedParams = ctx.keyedArg && ctx.keyedArg.map(item => this.visit([item]));
+    const pars = (params || keyedParams) && [...(params ?? []), ...(keyedParams ?? [])];
+    return { type: 'function', name, params: pars };
   }
 
   array(ctx: CstNode & { value: CstNode[] }): Types.RelationArray {

--- a/test/PrismaSchemaBuilder.test.ts
+++ b/test/PrismaSchemaBuilder.test.ts
@@ -322,6 +322,14 @@ describe('PrismaSchemaBuilder', () => {
         USER // basic role
         ADMIN // more powerful role
       }
+
+      model Indexed {
+        id  String @id(map: \\"PK_indexed\\") @db.UniqueIdentifier
+        foo String @db.UniqueIdentifier
+        bar String @db.UniqueIdentifier
+
+        @@index([foo, bar(sort: Desc)], map: \\"IX_indexed_indexedFoo\\")
+      }
       "
     `);
   });

--- a/test/__snapshots__/getSchema.test.ts.snap
+++ b/test/__snapshots__/getSchema.test.ts.snap
@@ -7111,6 +7111,113 @@ exports[`getSchema parse example.prisma 1`] = `
           \\"comment\\": \\"// more powerful role\\"
         }
       ]
+    },
+    {
+      \\"type\\": \\"break\\"
+    },
+    {
+      \\"type\\": \\"model\\",
+      \\"name\\": \\"Indexed\\",
+      \\"properties\\": [
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"id\\",
+          \\"fieldType\\": \\"String\\",
+          \\"array\\": false,
+          \\"optional\\": false,
+          \\"attributes\\": [
+            {
+              \\"type\\": \\"attribute\\",
+              \\"name\\": \\"id\\",
+              \\"kind\\": \\"field\\",
+              \\"args\\": [
+                {
+                  \\"type\\": \\"attributeArgument\\",
+                  \\"value\\": {
+                    \\"type\\": \\"keyValue\\",
+                    \\"key\\": \\"map\\",
+                    \\"value\\": \\"\\\\\\"PK_indexed\\\\\\"\\"
+                  }
+                }
+              ]
+            },
+            {
+              \\"type\\": \\"attribute\\",
+              \\"name\\": \\"UniqueIdentifier\\",
+              \\"kind\\": \\"field\\",
+              \\"group\\": \\"db\\"
+            }
+          ]
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"foo\\",
+          \\"fieldType\\": \\"String\\",
+          \\"array\\": false,
+          \\"optional\\": false,
+          \\"attributes\\": [
+            {
+              \\"type\\": \\"attribute\\",
+              \\"name\\": \\"UniqueIdentifier\\",
+              \\"kind\\": \\"field\\",
+              \\"group\\": \\"db\\"
+            }
+          ]
+        },
+        {
+          \\"type\\": \\"field\\",
+          \\"name\\": \\"bar\\",
+          \\"fieldType\\": \\"String\\",
+          \\"array\\": false,
+          \\"optional\\": false,
+          \\"attributes\\": [
+            {
+              \\"type\\": \\"attribute\\",
+              \\"name\\": \\"UniqueIdentifier\\",
+              \\"kind\\": \\"field\\",
+              \\"group\\": \\"db\\"
+            }
+          ]
+        },
+        {
+          \\"type\\": \\"break\\"
+        },
+        {
+          \\"type\\": \\"attribute\\",
+          \\"name\\": \\"index\\",
+          \\"kind\\": \\"model\\",
+          \\"args\\": [
+            {
+              \\"type\\": \\"attributeArgument\\",
+              \\"value\\": {
+                \\"type\\": \\"array\\",
+                \\"args\\": [
+                  \\"foo\\",
+                  {
+                    \\"type\\": \\"function\\",
+                    \\"name\\": \\"bar\\",
+                    \\"params\\": [
+                      {
+                        \\"type\\": \\"keyValue\\",
+                        \\"key\\": \\"sort\\",
+                        \\"value\\": \\"Desc\\"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              \\"type\\": \\"attributeArgument\\",
+              \\"value\\": {
+                \\"type\\": \\"keyValue\\",
+                \\"key\\": \\"map\\",
+                \\"value\\": \\"\\\\\\"IX_indexed_indexedFoo\\\\\\"\\"
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }"

--- a/test/__snapshots__/printSchema.test.ts.snap
+++ b/test/__snapshots__/printSchema.test.ts.snap
@@ -616,6 +616,14 @@ enum Role {
   USER // basic role
   ADMIN // more powerful role
 }
+
+model Indexed {
+  id  String @id(map: \\"PK_indexed\\") @db.UniqueIdentifier
+  foo String @db.UniqueIdentifier
+  bar String @db.UniqueIdentifier
+
+  @@index([foo, bar(sort: Desc)], map: \\"IX_indexed_indexedFoo\\")
+}
 "
 `;
 

--- a/test/fixtures/example.prisma
+++ b/test/fixtures/example.prisma
@@ -58,3 +58,11 @@ enum Role {
   USER // basic role
   ADMIN // more powerful role
 }
+
+model Indexed {
+  id                    String   @id(map: "PK_indexed") @db.UniqueIdentifier
+  foo                   String   @db.UniqueIdentifier
+  bar                   String   @db.UniqueIdentifier
+
+  @@index([foo, bar(sort: Desc)], map: "IX_indexed_indexedFoo")
+}


### PR DESCRIPTION
This is needed for supporting parsing and modifying sorted indices (see tests).
I also made array printing treat the array's elements as value nodes (which is in line with the parser and actual schema files) rather than primitives.