### PR TITLE
fix exponential backtracking in String regex

### DIFF
--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -128,7 +128,7 @@ export const Equals = createToken({
 });
 export const StringLiteral = createToken({
   name: 'StringLiteral',
-  pattern: /"(:?[^\\"\n\r]+|\\(:?[bfnrtv"\\/]|u[0-9a-fA-F]{4}))*"/,
+  pattern: /"(:?[^\\"\n\r]|\\(:?[bfnrtv"\\/]|u[0-9a-fA-F]{4}))*"/,
 });
 export const NumberLiteral = createToken({
   name: 'NumberLiteral',


### PR DESCRIPTION
avoid exponential backtracking while resolve StringLiteral without closing quotes

generator db {
  provider = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
}