### PR TITLE
feat: add composite types

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,36 @@ model Project {
 }
 ```
 
+### Add or update a view
+
+If the view with that name already exists in the schema, it will be selected and any fields that follow will be appended to the view. Otherwise, the view will be created and added to the schema.
+
+```ts
+builder.view('Project').field('name', 'String');
+```
+
+```prisma
+model Project {
+  name String
+}
+```
+
+### Add or update a composite type
+
+If the composite type with that name already exists in the schema, it will be selected and any fields that follow will be appended to the type. Otherwise, the composite type will be created and added to the schema.
+
+```ts
+builder.type('Photo').field('width', 'Int').field('height', 'Int').field('url', 'String');
+```
+
+```prisma
+type Photo {
+  width   Int
+  height  Int
+  url     String
+}
+```
+
 ### Access a model programmatically
 
 If you want to perform a custom action that there isn't a Builder method for, you can access the underlying schema object programmatically.

--- a/src/getSchema.ts
+++ b/src/getSchema.ts
@@ -44,10 +44,11 @@ export type Block =
   | Generator
   | Enum
   | Comment
-  | Break;
+  | Break
+  | Type;
 
 export interface Object {
-  type: 'model' | 'view';
+  type: 'model' | 'view' | 'type';
   name: string;
   properties: Array<Property | Comment | Break>;
 }
@@ -59,6 +60,11 @@ export interface Model extends Object {
 
 export interface View extends Object {
   type: 'view';
+  location?: CstNodeLocation;
+}
+
+export interface Type extends Object {
+  type: 'type';
   location?: CstNodeLocation;
 }
 
@@ -109,7 +115,7 @@ export interface Enumerator {
 
 export interface BlockAttribute {
   type: 'attribute';
-  kind: 'object' | 'view';
+  kind: 'object' | 'view' | 'type';
   group?: string;
   name: string;
   args: AttributeArgument[];

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -29,6 +29,11 @@ export const Enum = createToken({
   pattern: /enum/,
   push_mode: 'block',
 });
+export const Type = createToken({
+  name: 'Type',
+  pattern: /type/,
+  push_mode: 'block',
+});
 export const True = createToken({
   name: 'True',
   pattern: /true/,
@@ -155,7 +160,7 @@ const naTokens = [Comment, DocComment, LineComment, LineBreak, WhiteSpace];
 
 export const multiModeTokens: IMultiModeLexerDefinition = {
   modes: {
-    global: [...naTokens, Datasource, Generator, Model, View, Enum],
+    global: [...naTokens, Datasource, Generator, Model, View, Enum, Type],
     block: [
       ...naTokens,
       Attribute,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2,7 +2,13 @@ import { CstParser } from 'chevrotain';
 import getConfig, { PrismaAstParserConfig } from './getConfig';
 import * as lexer from './lexer';
 
-type ComponentType = 'datasource' | 'generator' | 'model' | 'view' | 'enum';
+type ComponentType =
+  | 'datasource'
+  | 'generator'
+  | 'model'
+  | 'view'
+  | 'enum'
+  | 'type';
 export class PrismaParser extends CstParser {
   readonly config: PrismaAstParserConfig;
 
@@ -105,7 +111,10 @@ export class PrismaParser extends CstParser {
     ) => {
       const { componentType } = options;
       const isEnum = componentType === 'enum';
-      const isObject = componentType === 'model' || componentType === 'view';
+      const isObject =
+        componentType === 'model' ||
+        componentType === 'view' ||
+        componentType === 'type';
 
       this.CONSUME(lexer.LCurly);
       this.CONSUME1(lexer.LineBreak);
@@ -197,6 +206,7 @@ export class PrismaParser extends CstParser {
       { ALT: () => this.CONSUME(lexer.Model, { LABEL: 'type' }) },
       { ALT: () => this.CONSUME(lexer.View, { LABEL: 'type' }) },
       { ALT: () => this.CONSUME(lexer.Enum, { LABEL: 'type' }) },
+      { ALT: () => this.CONSUME(lexer.Type, { LABEL: 'type' }) },
     ]);
     this.OR2([
       {

--- a/src/printSchema.ts
+++ b/src/printSchema.ts
@@ -2,10 +2,12 @@ import * as Types from './getSchema';
 import { EOL } from 'os';
 import { schemaSorter } from './schemaSorter';
 
+type Block = 'generator' | 'datasource' | 'model' | 'view' | 'enum' | 'type';
+
 export interface PrintOptions {
   sort?: boolean;
   locales?: string | string[];
-  sortOrder?: Array<'generator' | 'datasource' | 'model' | 'view' | 'enum'>;
+  sortOrder?: Block[];
 }
 
 /**
@@ -47,6 +49,7 @@ function printBlock(block: Types.Block): string {
       return printGenerator(block);
     case 'model':
     case 'view':
+    case 'type':
       return printObject(block);
     case 'break':
       return printBreak();

--- a/src/schemaUtils.ts
+++ b/src/schemaUtils.ts
@@ -1,9 +1,9 @@
 import type { CstNode, IToken } from 'chevrotain';
 import * as schema from './getSchema';
 
-const schemaObjects = ['model', 'view'];
+const schemaObjects = ['model', 'view', 'type'];
 
-/** Returns true if the value is an Object, such as a model or view. */
+/** Returns true if the value is an Object, such as a model or view or composite type. */
 export function isSchemaObject(obj: schema.Object): boolean {
   return obj != null && 'type' in obj && schemaObjects.includes(obj.type);
 }

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -5,8 +5,10 @@ import { appendLocationData, isToken } from './schemaUtils';
 import { PrismaParser, defaultParser } from './parser';
 import { ICstVisitor } from 'chevrotain';
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 type Class<T> = new (...args: any[]) => T;
 export type PrismaVisitor = ICstVisitor<any, any>;
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 export const VisitorClassFactory = (
   parser: PrismaParser
@@ -65,6 +67,12 @@ export const VisitorClassFactory = (
               type: 'enum',
               name: name.image,
               enumerators: list,
+            } as const;
+          case 'type':
+            return {
+              type: 'type',
+              name: name.image,
+              properties: list,
             } as const;
           default:
             throw new Error(`Unexpected block type: ${type}`);

--- a/test/PrismaSchemaBuilder.test.ts
+++ b/test/PrismaSchemaBuilder.test.ts
@@ -591,6 +591,32 @@ describe('PrismaSchemaBuilder', () => {
       `);
   });
 
+  it('adds a composite type', async () => {
+    const builder = createPrismaSchemaBuilder(`
+    datasource db {
+      provider = "mongodb"
+      url      = env("DATABASE_URL")
+    }
+    
+    model Product {
+      id     String  @id @default(auto()) @map("_id") @db.ObjectId
+      name   String
+      photos Photo[]
+    }
+    `);
+
+    const result = builder
+      .type('Photo')
+      .field('height', 'Int')
+      .attribute('default', ['0'])
+      .field('width', 'Int')
+      .attribute('default', ['0'])
+      .field('url', 'String')
+      .print();
+
+    expect(result).toMatch(await loadFixture('composite-types.prisma'));
+  });
+
   it('prints the schema', async () => {
     const source = await loadFixture('example.prisma');
     const result = createPrismaSchemaBuilder(source).print();

--- a/test/PrismaSchemaBuilder.test.ts
+++ b/test/PrismaSchemaBuilder.test.ts
@@ -614,7 +614,7 @@ describe('PrismaSchemaBuilder', () => {
       .field('url', 'String')
       .print();
 
-    expect(result).toMatch(await loadFixture('composite-types.prisma'));
+    expect(result).toMatchSnapshot();
   });
 
   it('prints the schema', async () => {

--- a/test/__snapshots__/PrismaSchemaBuilder.test.ts.snap
+++ b/test/__snapshots__/PrismaSchemaBuilder.test.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PrismaSchemaBuilder adds a composite type 1`] = `
+"
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+}
+
+model Product {
+  id     String  @id @default(auto()) @map("_id") @db.ObjectId
+  name   String
+  photos Photo[]
+}
+
+type Photo {
+  height Int    @default(0)
+  width  Int    @default(0)
+  url    String
+}
+"
+`;

--- a/test/__snapshots__/getSchema.test.ts.snap
+++ b/test/__snapshots__/getSchema.test.ts.snap
@@ -7405,6 +7405,177 @@ exports[`getSchema parse atena-server.prisma 1`] = `
 }
 `;
 
+exports[`getSchema parse composite-types.prisma 1`] = `
+{
+  "list": [
+    {
+      "assignments": [
+        {
+          "key": "provider",
+          "type": "assignment",
+          "value": ""mongodb"",
+        },
+        {
+          "key": "url",
+          "type": "assignment",
+          "value": {
+            "name": "env",
+            "params": [
+              ""DATABASE_URL"",
+            ],
+            "type": "function",
+          },
+        },
+      ],
+      "name": "db",
+      "type": "datasource",
+    },
+    {
+      "type": "break",
+    },
+    {
+      "name": "Product",
+      "properties": [
+        {
+          "array": false,
+          "attributes": [
+            {
+              "args": undefined,
+              "group": undefined,
+              "kind": "field",
+              "name": "id",
+              "type": "attribute",
+            },
+            {
+              "args": [
+                {
+                  "type": "attributeArgument",
+                  "value": {
+                    "name": "auto",
+                    "params": undefined,
+                    "type": "function",
+                  },
+                },
+              ],
+              "group": undefined,
+              "kind": "field",
+              "name": "default",
+              "type": "attribute",
+            },
+            {
+              "args": [
+                {
+                  "type": "attributeArgument",
+                  "value": ""_id"",
+                },
+              ],
+              "group": undefined,
+              "kind": "field",
+              "name": "map",
+              "type": "attribute",
+            },
+            {
+              "args": undefined,
+              "group": "db",
+              "kind": "field",
+              "name": "ObjectId",
+              "type": "attribute",
+            },
+          ],
+          "comment": undefined,
+          "fieldType": "String",
+          "name": "id",
+          "optional": false,
+          "type": "field",
+        },
+        {
+          "array": false,
+          "attributes": undefined,
+          "comment": undefined,
+          "fieldType": "String",
+          "name": "name",
+          "optional": false,
+          "type": "field",
+        },
+        {
+          "array": true,
+          "attributes": undefined,
+          "comment": undefined,
+          "fieldType": "Photo",
+          "name": "photos",
+          "optional": false,
+          "type": "field",
+        },
+      ],
+      "type": "model",
+    },
+    {
+      "type": "break",
+    },
+    {
+      "name": "Photo",
+      "properties": [
+        {
+          "array": false,
+          "attributes": [
+            {
+              "args": [
+                {
+                  "type": "attributeArgument",
+                  "value": "0",
+                },
+              ],
+              "group": undefined,
+              "kind": "field",
+              "name": "default",
+              "type": "attribute",
+            },
+          ],
+          "comment": undefined,
+          "fieldType": "Int",
+          "name": "height",
+          "optional": false,
+          "type": "field",
+        },
+        {
+          "array": false,
+          "attributes": [
+            {
+              "args": [
+                {
+                  "type": "attributeArgument",
+                  "value": "0",
+                },
+              ],
+              "group": undefined,
+              "kind": "field",
+              "name": "default",
+              "type": "attribute",
+            },
+          ],
+          "comment": undefined,
+          "fieldType": "Int",
+          "name": "width",
+          "optional": false,
+          "type": "field",
+        },
+        {
+          "array": false,
+          "attributes": undefined,
+          "comment": undefined,
+          "fieldType": "String",
+          "name": "url",
+          "optional": false,
+          "type": "field",
+        },
+      ],
+      "type": "type",
+    },
+  ],
+  "type": "schema",
+}
+`;
+
 exports[`getSchema parse empty-comment.prisma 1`] = `
 {
   "list": [

--- a/test/__snapshots__/printSchema.test.ts.snap
+++ b/test/__snapshots__/printSchema.test.ts.snap
@@ -555,6 +555,27 @@ model AccountabilityData {
 "
 `;
 
+exports[`printSchema print composite-types.prisma 1`] = `
+"
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+}
+
+model Product {
+  id     String  @id @default(auto()) @map("_id") @db.ObjectId
+  name   String
+  photos Photo[]
+}
+
+type Photo {
+  height Int    @default(0)
+  width  Int    @default(0)
+  url    String
+}
+"
+`;
+
 exports[`printSchema print empty-comment.prisma 1`] = `
 "
 datasource db {

--- a/test/fixtures/composite-types.prisma
+++ b/test/fixtures/composite-types.prisma
@@ -1,0 +1,16 @@
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+}
+
+model Product {
+  id     String  @id @default(auto()) @map("_id") @db.ObjectId
+  name   String
+  photos Photo[]
+}
+
+type Photo {
+  height Int    @default(0)
+  width  Int    @default(0)
+  url    String
+}

--- a/test/getSchema.test.ts
+++ b/test/getSchema.test.ts
@@ -94,6 +94,35 @@ describe('getSchema', () => {
     });
   });
 
+  it('parses composite type', async () => {
+    const source = await loadFixture('composite-types.prisma');
+    const schema = getSchema(source);
+
+    for (const node of schema.list) {
+      if (node.type === 'type' && node.name === 'Photo') {
+        const [height, width, url] = node.properties;
+        expect(height).toMatchObject({
+          type: 'field',
+          name: 'height',
+          fieldType: 'Int',
+        });
+        expect(width).toMatchObject({
+          type: 'field',
+          name: 'width',
+          fieldType: 'Int',
+        });
+        expect(url).toMatchObject({
+          type: 'field',
+          name: 'url',
+          fieldType: 'String',
+        });
+        return;
+      }
+    }
+
+    fail();
+  });
+
   describe('with location tracking', () => {
     describe('passed-in parser and visitor', () => {
       it('contains field location info', async () => {


### PR DESCRIPTION
Adds [composite types](https://www.prisma.io/docs/orm/prisma-client/special-fields-and-types/composite-types) to the parser, printer, and Schema Builder

```prisma
model Gallery {
  photos Photo[]
}

type Photo {
  width Int
  height Int
  url String
}
```

The schema node is `{ type: "type" }` and the builder method is `builder.type("Photo")`