### PR TITLE
Add finder methods to builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,37 @@ model User {
 }
 ```
 
+### Query the prisma schema for specific objects
+
+The builder can also help you find matching objects in the schema based on name (by string or RegExp) or parent context. You can use this to write tests against your schema, or find fields that don't match a naming convention, for example.
+
+```ts
+const source = `
+  model Product {
+    id     String  @id @default(auto()) @map("_id") @db.ObjectId
+    name   String
+    photos Photo[]
+  }
+`
+
+const builder = createPrismaSchemaBuilder(source);
+
+const product = builder.findByType('model', { name: 'Product' });
+expect(product).toHaveProperty('name', 'Product');
+
+const id = builder.findByType('field', {
+  name: 'id',
+  within: product?.properties,
+});
+expect(id).toHaveProperty('name', 'id');
+
+const map = builder.findByType('attribute', {
+  name: 'map',
+  within: id?.attributes,
+});
+expect(map).toHaveProperty('name', 'map');
+```
+
 ### Re-sort the schema
 
 prisma-ast can sort the schema for you. The default sort order is `['generator', 'datasource', 'model', 'enum']` and will sort objects of the same type alphabetically.

--- a/src/finder.ts
+++ b/src/finder.ts
@@ -1,0 +1,55 @@
+import type * as schema from './getSchema';
+
+export type ByTypeSourceObject =
+  | schema.Block
+  | schema.Enumerator
+  | schema.Field
+  | schema.Property
+  | schema.Attribute;
+
+export type ByTypeMatchObject = Exclude<
+  ByTypeSourceObject,
+  schema.Comment | schema.Break
+>;
+export type ByTypeMatch = ByTypeMatchObject['type'];
+export type ByTypeOptions = { name?: string | RegExp };
+export type FindByBlock<Match> = Extract<ByTypeMatchObject, { type: Match }>;
+
+export const findByType = <const Match extends ByTypeMatch>(
+  list: ByTypeSourceObject[],
+  typeToMatch: Match,
+  options: ByTypeOptions = {}
+): FindByBlock<Match> | null => {
+  const [match, unexpected] = list.filter(findBy(typeToMatch, options));
+
+  if (!match) return null;
+
+  if (unexpected)
+    throw new Error(`Found multiple blocks with [type=${typeToMatch}]`);
+
+  return match;
+};
+
+export const findAllByType = <const Match extends ByTypeMatch>(
+  list: ByTypeSourceObject[],
+  typeToMatch: Match,
+  options: ByTypeOptions = {}
+): Array<FindByBlock<Match>> => {
+  return list.filter(findBy(typeToMatch, options));
+};
+
+const findBy =
+  <Match extends ByTypeMatch>(
+    typeToMatch: Match,
+    { name }: ByTypeOptions = {}
+  ) =>
+  (block: ByTypeSourceObject): block is FindByBlock<Match> => {
+    if (name != null) {
+      if (!('name' in block)) return false;
+      const nameMatches =
+        typeof name === 'string' ? block.name === name : name.test(block.name);
+      if (!nameMatches) return false;
+    }
+
+    return block.type === typeToMatch;
+  };

--- a/test/finder.test.ts
+++ b/test/finder.test.ts
@@ -1,0 +1,78 @@
+import { createPrismaSchemaBuilder } from '../src/PrismaSchemaBuilder';
+import { loadFixture } from './utils';
+
+describe('finder', () => {
+  it('finds a model', async () => {
+    const source = await loadFixture('example.prisma');
+    const finder = createPrismaSchemaBuilder(source);
+
+    const model = finder.findByType('model', { name: 'Indexed' });
+    expect(model).toHaveProperty('name', 'Indexed');
+  });
+
+  it('finds all matching models', async () => {
+    const source = await loadFixture('atena-server.prisma');
+    const finder = createPrismaSchemaBuilder(source);
+
+    const [proposalData, data, accountabilityData, unexpected] =
+      finder.findAllByType('model', {
+        name: /Data$/,
+      });
+    expect(proposalData).toHaveProperty('name', 'ProposalData');
+    expect(data).toHaveProperty('name', 'Data');
+    expect(accountabilityData).toHaveProperty('name', 'AccountabilityData');
+    expect(unexpected).toBeUndefined();
+  });
+
+  it('finds an enumerator', async () => {
+    const source = await loadFixture('atena-server.prisma');
+    const finder = createPrismaSchemaBuilder(source);
+
+    const groupAccess = finder.findByType('enum', { name: 'GroupAccess' });
+    expect(groupAccess).toHaveProperty('name', 'GroupAccess');
+
+    const cities = finder.findByType('enumerator', {
+      name: 'CITIES',
+      within: groupAccess?.enumerators,
+    });
+
+    expect(cities).toHaveProperty('name', 'CITIES');
+  });
+
+  it('finds all matching fields', async () => {
+    const source = await loadFixture('empty-comment.prisma');
+    const finder = createPrismaSchemaBuilder(source);
+
+    const product = finder.findByType('model', { name: 'Product' });
+    expect(product).toHaveProperty('name', 'Product');
+
+    const [unit, unitOfMeasurement, unexpected] = finder.findAllByType(
+      'field',
+      { name: /unit/i, within: product?.properties }
+    );
+    expect(unit).toHaveProperty('name', 'unit');
+    expect(unitOfMeasurement).toHaveProperty('name', 'unitOfMeasurement');
+    expect(unexpected).toBeUndefined();
+  });
+
+  it('finds an attribute', async () => {
+    const source = await loadFixture('composite-types.prisma');
+    const finder = createPrismaSchemaBuilder(source);
+
+    const product = finder.findByType('model', { name: 'Product' });
+    expect(product).toHaveProperty('name', 'Product');
+
+    const id = finder.findByType('field', {
+      name: 'id',
+      within: product?.properties,
+    });
+    expect(id).toHaveProperty('name', 'id');
+
+    const map = finder.findByType('attribute', {
+      name: 'map',
+      within: id?.attributes,
+    });
+    expect(map).toHaveProperty('name', 'map');
+    expect(map).toHaveProperty(['args', 0, 'value'], '"_id"');
+  });
+});


### PR DESCRIPTION
Sample Schema
```prisma
model Product {
  id     String  @id @default(auto()) @map("_id") @db.ObjectId
  name   String
  photos Photo[]

  thumbnailUrl String
  previewUrl   String
}
```

Find a model by name

```ts
const product = builder.findByType("model", { name: "Product" })
expect(product).toHaveProperty("name", "Product")
```

Find all fields by pattern

```ts
const [thumbnailUrl, previewUrl] = builder.findAllByType("field", { name: /Url/, within: product.properties })
expect(thumbnailUrl).toHaveProperty("name", "thumbnailUrl")
expect(previewUrl).toHaveProperty("name", "previewUrl")
```
