### PR TITLE
Fix mismatch token on kebab case

### DIFF
--- a/src/finder.ts
+++ b/src/finder.ts
@@ -5,7 +5,8 @@ export type ByTypeSourceObject =
   | schema.Enumerator
   | schema.Field
   | schema.Property
-  | schema.Attribute;
+  | schema.Attribute
+  | schema.Assignment;
 
 export type ByTypeMatchObject = Exclude<
   ByTypeSourceObject,
@@ -38,16 +39,26 @@ export const findAllByType = <const Match extends ByTypeMatch>(
   return list.filter(findBy(typeToMatch, options));
 };
 
+type NameOf<Match extends ByTypeMatch> = Extract<
+  Match,
+  Match extends 'assignment' ? 'key' : 'name'
+>;
+
 const findBy =
-  <Match extends ByTypeMatch>(
+  <Match extends ByTypeMatch, MatchName extends NameOf<Match>>(
     typeToMatch: Match,
     { name }: ByTypeOptions = {}
   ) =>
   (block: ByTypeSourceObject): block is FindByBlock<Match> => {
     if (name != null) {
-      if (!('name' in block)) return false;
+      const nameAttribute = (
+        typeToMatch === 'assignment' ? 'key' : 'name'
+      ) as MatchName;
+      if (!(nameAttribute in block)) return false;
       const nameMatches =
-        typeof name === 'string' ? block.name === name : name.test(block.name);
+        typeof name === 'string'
+          ? block[nameAttribute] === name
+          : name.test(block[nameAttribute]);
       if (!nameMatches) return false;
     }
 

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -2,7 +2,7 @@ import { createToken, Lexer, IMultiModeLexerDefinition } from 'chevrotain';
 
 export const Identifier = createToken({
   name: 'Identifier',
-  pattern: /[a-zA-Z]\w*/,
+  pattern: /[a-zA-Z][\w-]*/,
 });
 export const Datasource = createToken({
   name: 'Datasource',

--- a/test/__snapshots__/getSchema.test.ts.snap
+++ b/test/__snapshots__/getSchema.test.ts.snap
@@ -8816,6 +8816,40 @@ exports[`getSchema parse example.prisma 1`] = `
 }
 `;
 
+exports[`getSchema parse kebab-case.prisma 1`] = `
+{
+  "list": [
+    {
+      "assignments": [
+        {
+          "key": "provider",
+          "type": "assignment",
+          "value": ""node ./dist/apps/prisma-model-generator/src/generator.js"",
+        },
+        {
+          "key": "fileNamingStyle",
+          "type": "assignment",
+          "value": ""kebab"",
+        },
+        {
+          "key": "classNamingStyle",
+          "type": "assignment",
+          "value": ""pascal"",
+        },
+        {
+          "key": "output",
+          "type": "assignment",
+          "value": ""./generated/"",
+        },
+      ],
+      "name": "prisma-model-generator",
+      "type": "generator",
+    },
+  ],
+  "type": "schema",
+}
+`;
+
 exports[`getSchema parse links.prisma 1`] = `
 {
   "list": [

--- a/test/__snapshots__/printSchema.test.ts.snap
+++ b/test/__snapshots__/printSchema.test.ts.snap
@@ -694,6 +694,17 @@ model Indexed {
 "
 `;
 
+exports[`printSchema print kebab-case.prisma 1`] = `
+"
+generator prisma-model-generator {
+  provider         = "node ./dist/apps/prisma-model-generator/src/generator.js"
+  fileNamingStyle  = "kebab"
+  classNamingStyle = "pascal"
+  output           = "./generated/"
+}
+"
+`;
+
 exports[`printSchema print links.prisma 1`] = `
 "
 datasource db {

--- a/test/finder.test.ts
+++ b/test/finder.test.ts
@@ -75,4 +75,20 @@ describe('finder', () => {
     expect(map).toHaveProperty('name', 'map');
     expect(map).toHaveProperty(['args', 0, 'value'], '"_id"');
   });
+
+  it('finds an assignment', async () => {
+    const source = await loadFixture('kebab-case.prisma');
+    const finder = createPrismaSchemaBuilder(source);
+
+    const generator = finder.findByType('generator', {
+      name: 'prisma-model-generator',
+    });
+    expect(generator).toHaveProperty('name', 'prisma-model-generator');
+
+    const assignment = finder.findByType('assignment', {
+      name: 'fileNamingStyle',
+      within: generator?.assignments,
+    });
+    expect(assignment).toHaveProperty('value', '"kebab"');
+  });
 });

--- a/test/fixtures/kebab-case.prisma
+++ b/test/fixtures/kebab-case.prisma
@@ -1,0 +1,6 @@
+generator prisma-model-generator {
+  provider         = "node ./dist/apps/prisma-model-generator/src/generator.js"
+  fileNamingStyle  = "kebab"
+  classNamingStyle = "pascal"
+  output           = "./generated/"
+}


### PR DESCRIPTION
- Adds hyphen as an allowed character in identifiers.
- Also allows `builder.findBy("assignment", { name: "provider", within: generator.assignments })` syntax to select generator assignments.