### PR TITLE
feat: Allow @map() and other attributes on enums

### DIFF
--- a/src/getSchema.ts
+++ b/src/getSchema.ts
@@ -85,7 +85,9 @@ export interface Generator {
 export interface Enum {
   type: 'enum';
   name: string;
-  enumerators: Array<Enumerator | Comment | Break>;
+  enumerators: Array<
+    Enumerator | Comment | Break | BlockAttribute | GroupedAttribute
+  >;
   location?: CstNodeLocation;
 }
 
@@ -110,6 +112,7 @@ export interface Enumerator {
   type: 'enumerator';
   name: string;
   value?: Value;
+  attributes?: Attribute[];
   comment?: string;
 }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -148,6 +148,9 @@ export class PrismaParser extends CstParser {
 
   private enum = this.RULE('enum', () => {
     this.CONSUME(lexer.Identifier, { LABEL: 'enumName' });
+    this.MANY(() => {
+      this.SUBRULE(this.fieldAttribute, { LABEL: 'attributeList' });
+    });
     this.OPTION(() => {
       this.CONSUME(lexer.Comment, { LABEL: 'comment' });
     });

--- a/src/printSchema.ts
+++ b/src/printSchema.ts
@@ -76,9 +76,17 @@ datasource ${db.name} {
 }
 
 function printEnum(enumerator: Types.Enum) {
-  const children = enumerator.enumerators
-    .map(printEnumerator)
+  const list: Array<
+    | Types.Comment
+    | Types.Break
+    | Types.Enumerator
+    | Types.BlockAttribute
+    | Types.GroupedBlockAttribute
+    | Types.GroupedAttribute
+  > = enumerator.enumerators;
+  const children = list
     .filter(Boolean)
+    .map(printEnumerator)
     .join(`${EOL}  `)
     .replace(/(\r?\n\s*){3,}/g, `${EOL + EOL}  `);
 
@@ -89,11 +97,24 @@ enum ${enumerator.name} {
 }
 
 function printEnumerator(
-  enumerator: Types.Enumerator | Types.Attribute | Types.Comment | Types.Break
+  enumerator:
+    | Types.Enumerator
+    | Types.Attribute
+    | Types.Comment
+    | Types.Break
+    | Types.BlockAttribute
+    | Types.GroupedBlockAttribute
+    | Types.GroupedAttribute
 ) {
   switch (enumerator.type) {
-    case 'enumerator':
-      return [enumerator.name, enumerator.comment].filter(Boolean).join(' ');
+    case 'enumerator': {
+      const attrs = enumerator.attributes
+        ? enumerator.attributes.map(printAttribute)
+        : [];
+      return [enumerator.name, ...attrs, enumerator.comment]
+        .filter(Boolean)
+        .join(' ');
+    }
     case 'attribute':
       return printAttribute(enumerator);
     case 'comment':

--- a/src/schemaUtils.ts
+++ b/src/schemaUtils.ts
@@ -1,16 +1,28 @@
 import type { CstNode, IToken } from 'chevrotain';
 import * as schema from './getSchema';
 
-const schemaObjects = ['model', 'view', 'type'];
+const schemaObjects = ['model', 'view', 'type'] as const;
 
-/** Returns true if the value is an Object, such as a model or view or composite type. */
-export function isSchemaObject(obj: schema.Object): boolean {
-  return obj != null && 'type' in obj && schemaObjects.includes(obj.type);
+export function isOneOfSchemaObjects<T extends string>(
+  obj: schema.Object,
+  schemas: readonly T[]
+): obj is Extract<schema.Object, { type: T }> {
+  return obj != null && 'type' in obj && schemas.includes(obj.type as T);
 }
 
-/** Returns true if the value is a Field. */
-export function isSchemaField(field: schema.Field): boolean {
-  return field != null && 'type' in field && field.type === 'field';
+/** Returns true if the value is an Object, such as a model or view or composite type. */
+export function isSchemaObject(
+  obj: schema.Object
+): obj is Extract<schema.Object, { type: (typeof schemaObjects)[number] }> {
+  return isOneOfSchemaObjects(obj, schemaObjects);
+}
+
+const fieldObjects = ['field', 'enumerator'] as const;
+/** Returns true if the value is a Field or Enumerator. */
+export function isSchemaField(
+  field: schema.Field | schema.Enumerator
+): field is Extract<schema.Field, { type: (typeof fieldObjects)[number] }> {
+  return field != null && 'type' in field && fieldObjects.includes(field.type);
 }
 
 /** Returns true if the value of the CstNode is a Token. */

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -43,37 +43,37 @@ export const VisitorClassFactory = (
               type: 'datasource',
               name: name.image,
               assignments: list,
-            } as const;
+            } as const satisfies Types.Datasource;
           case 'generator':
             return {
               type: 'generator',
               name: name.image,
               assignments: list,
-            } as const;
+            } as const satisfies Types.Generator;
           case 'model':
             return {
               type: 'model',
               name: name.image,
               properties: list,
-            } as const;
+            } as const satisfies Types.Model;
           case 'view':
             return {
               type: 'view',
               name: name.image,
               properties: list,
-            } as const;
+            } as const satisfies Types.View;
           case 'enum':
             return {
               type: 'enum',
               name: name.image,
               enumerators: list,
-            } as const;
+            } as const satisfies Types.Enum;
           case 'type':
             return {
               type: 'type',
               name: name.image,
               properties: list,
-            } as const;
+            } as const satisfies Types.Type;
           default:
             throw new Error(`Unexpected block type: ${type}`);
         }
@@ -88,7 +88,10 @@ export const VisitorClassFactory = (
 
     comment(ctx: CstNode & { text: [IToken] }): Types.Comment {
       const [comment] = ctx.text;
-      const data = { type: 'comment', text: comment.image } as const;
+      const data = {
+        type: 'comment',
+        text: comment.image,
+      } as const satisfies Types.Comment;
       return this.maybeAppendLocationData(data, comment);
     }
 
@@ -101,7 +104,11 @@ export const VisitorClassFactory = (
     ): Types.Assignment {
       const value = this.visit(ctx.assignmentValue);
       const [key] = ctx.assignmentName;
-      const data = { type: 'assignment', key: key.image, value } as const;
+      const data = {
+        type: 'assignment',
+        key: key.image,
+        value,
+      } as const satisfies Types.Assignment;
       return this.maybeAppendLocationData(data, key);
     }
 
@@ -117,9 +124,7 @@ export const VisitorClassFactory = (
     ): Types.Field {
       const fieldType = this.visit(ctx.fieldType);
       const [name] = ctx.fieldName;
-      const attributes =
-        ctx.attributeList &&
-        ctx.attributeList.map((item) => this.visit([item]));
+      const attributes = ctx.attributeList?.map((item) => this.visit([item]));
       const comment = ctx.comment?.[0]?.image;
       const data = {
         type: 'field',
@@ -129,7 +134,7 @@ export const VisitorClassFactory = (
         optional: ctx.optional != null,
         attributes,
         comment,
-      } as const;
+      } as const satisfies Types.Field;
 
       return this.maybeAppendLocationData(
         data,
@@ -149,15 +154,14 @@ export const VisitorClassFactory = (
     ): Types.Attr {
       const [name] = ctx.attributeName;
       const [group] = ctx.groupName || [{}];
-      const args =
-        ctx.attributeArg && ctx.attributeArg.map((attr) => this.visit(attr));
+      const args = ctx.attributeArg?.map((attr) => this.visit(attr));
       const data = {
         type: 'attribute',
         name: name.image,
         kind: 'field',
         group: group.image,
         args,
-      } as const;
+      } as const satisfies Types.Attr;
       return this.maybeAppendLocationData(
         data,
         name,
@@ -176,15 +180,14 @@ export const VisitorClassFactory = (
     ): Types.Attr | null {
       const [name] = ctx.attributeName;
       const [group] = ctx.groupName || [{}];
-      const args =
-        ctx.attributeArg && ctx.attributeArg.map((attr) => this.visit(attr));
+      const args = ctx.attributeArg?.map((attr) => this.visit(attr));
       const data = {
         type: 'attribute',
         name: name.image,
         kind: 'object',
         group: group.image,
         args,
-      } as const;
+      } as const satisfies Types.Attr;
 
       return this.maybeAppendLocationData(
         data,
@@ -207,9 +210,8 @@ export const VisitorClassFactory = (
       }
     ): Types.Func {
       const [name] = ctx.funcName;
-      const params = ctx.value && ctx.value.map((item) => this.visit([item]));
-      const keyedParams =
-        ctx.keyedArg && ctx.keyedArg.map((item) => this.visit([item]));
+      const params = ctx.value?.map((item) => this.visit([item]));
+      const keyedParams = ctx.keyedArg?.map((item) => this.visit([item]));
       const pars = (params || keyedParams) && [
         ...(params ?? []),
         ...(keyedParams ?? []),
@@ -218,12 +220,12 @@ export const VisitorClassFactory = (
         type: 'function',
         name: name.image,
         params: pars,
-      } as const;
+      } as const satisfies Types.Func;
       return this.maybeAppendLocationData(data, name);
     }
 
     array(ctx: CstNode & { value: CstNode[] }): Types.RelationArray {
-      const args = ctx.value && ctx.value.map((item) => this.visit([item]));
+      const args = ctx.value?.map((item) => this.visit([item]));
       return { type: 'array', args };
     }
 
@@ -232,7 +234,11 @@ export const VisitorClassFactory = (
     ): Types.KeyValue {
       const [key] = ctx.keyName;
       const value = this.visit(ctx.value);
-      const data = { type: 'keyValue', key: key.image, value } as const;
+      const data = {
+        type: 'keyValue',
+        key: key.image,
+        value,
+      } as const satisfies Types.KeyValue;
       return this.maybeAppendLocationData(data, key);
     }
 
@@ -245,11 +251,21 @@ export const VisitorClassFactory = (
     }
 
     enum(
-      ctx: CstNode & { enumName: [IToken]; comment: [IToken] }
+      ctx: CstNode & {
+        enumName: [IToken];
+        attributeList: CstNode[];
+        comment: [IToken];
+      }
     ): Types.Enumerator {
       const [name] = ctx.enumName;
+      const attributes = ctx.attributeList?.map((item) => this.visit([item]));
       const comment = ctx.comment?.[0]?.image;
-      const data = { type: 'enumerator', name: name.image, comment } as const;
+      const data = {
+        type: 'enumerator',
+        name: name.image,
+        attributes,
+        comment,
+      } as const satisfies Types.Enumerator;
       return this.maybeAppendLocationData(data, name);
     }
 

--- a/test/PrismaSchemaBuilder.test.ts
+++ b/test/PrismaSchemaBuilder.test.ts
@@ -619,6 +619,37 @@ describe('PrismaSchemaBuilder', () => {
     expect(result).toMatchSnapshot();
   });
 
+  it('adds a mapped enum', async () => {
+    const builder = createPrismaSchemaBuilder(`
+    enum GradeLevel {
+      KINDERGARTEN   @map("kindergarten")
+      FIRST          @map("first")
+      SECOND         @map("second")
+      THIRD          @map("third")
+      FOURTH         @map("fourth")
+      FIFTH          @map("fifth")
+      SIXTH          @map("sixth")
+      SEVENTH        @map("seventh")
+      EIGHTH         @map("eighth")
+      NINTH          @map("ninth")
+      TENTH          @map("tenth")
+      ELEVENTH       @map("eleventh")
+      TWELFTH        @map("twelfth")
+      THIRTEEN       @map("thirteen")
+      POST_SECONDARY @map("post_secondary")
+      OTHER          @map("other")
+    }
+    `);
+
+    builder
+      .enum('GradeLevel')
+      .enumerator('FOO')
+      .attribute('map', ['"foo"'])
+      .break()
+      .blockAttribute('map', 'grades');
+    expect(builder.print()).toMatchSnapshot();
+  });
+
   it('prints the schema', async () => {
     const source = await loadFixture('example.prisma');
     const result = createPrismaSchemaBuilder(source).print();
@@ -680,8 +711,10 @@ describe('PrismaSchemaBuilder', () => {
       }
 
       enum Role {
-        USER // basic role
-        ADMIN // more powerful role
+        USER @map("usr") // basic role
+        ADMIN @map("adm") // more powerful role
+
+        @@map("roles")
       }
 
       model Indexed {

--- a/test/__snapshots__/PrismaSchemaBuilder.test.ts.snap
+++ b/test/__snapshots__/PrismaSchemaBuilder.test.ts.snap
@@ -20,3 +20,29 @@ type Photo {
 }
 "
 `;
+
+exports[`PrismaSchemaBuilder adds a mapped enum 1`] = `
+"
+enum GradeLevel {
+  KINDERGARTEN @map("kindergarten")
+  FIRST @map("first")
+  SECOND @map("second")
+  THIRD @map("third")
+  FOURTH @map("fourth")
+  FIFTH @map("fifth")
+  SIXTH @map("sixth")
+  SEVENTH @map("seventh")
+  EIGHTH @map("eighth")
+  NINTH @map("ninth")
+  TENTH @map("tenth")
+  ELEVENTH @map("eleventh")
+  TWELFTH @map("twelfth")
+  THIRTEEN @map("thirteen")
+  POST_SECONDARY @map("post_secondary")
+  OTHER @map("other")
+  FOO @map("foo")
+
+  @@map("grades")
+}
+"
+`;

--- a/test/__snapshots__/getSchema.test.ts.snap
+++ b/test/__snapshots__/getSchema.test.ts.snap
@@ -624,21 +624,25 @@ exports[`getSchema parse atena-server.prisma 1`] = `
     {
       "enumerators": [
         {
+          "attributes": undefined,
           "comment": undefined,
           "name": "ANY",
           "type": "enumerator",
         },
         {
+          "attributes": undefined,
           "comment": undefined,
           "name": "MUNICIPAL_SPHERE",
           "type": "enumerator",
         },
         {
+          "attributes": undefined,
           "comment": undefined,
           "name": "STATE_SPHERE",
           "type": "enumerator",
         },
         {
+          "attributes": undefined,
           "comment": undefined,
           "name": "CITIES",
           "type": "enumerator",
@@ -8067,11 +8071,13 @@ exports[`getSchema parse empty-comment.prisma 1`] = `
           "type": "comment",
         },
         {
+          "attributes": undefined,
           "comment": undefined,
           "name": "MARKDOWN",
           "type": "enumerator",
         },
         {
+          "attributes": undefined,
           "comment": "//",
           "name": "RICHTEXT",
           "type": "enumerator",
@@ -8683,14 +8689,57 @@ exports[`getSchema parse example.prisma 1`] = `
     {
       "enumerators": [
         {
+          "attributes": [
+            {
+              "args": [
+                {
+                  "type": "attributeArgument",
+                  "value": ""usr"",
+                },
+              ],
+              "group": undefined,
+              "kind": "field",
+              "name": "map",
+              "type": "attribute",
+            },
+          ],
           "comment": "// basic role",
           "name": "USER",
           "type": "enumerator",
         },
         {
+          "attributes": [
+            {
+              "args": [
+                {
+                  "type": "attributeArgument",
+                  "value": ""adm"",
+                },
+              ],
+              "group": undefined,
+              "kind": "field",
+              "name": "map",
+              "type": "attribute",
+            },
+          ],
           "comment": "// more powerful role",
           "name": "ADMIN",
           "type": "enumerator",
+        },
+        {
+          "type": "break",
+        },
+        {
+          "args": [
+            {
+              "type": "attributeArgument",
+              "value": ""roles"",
+            },
+          ],
+          "group": undefined,
+          "kind": "object",
+          "name": "map",
+          "type": "attribute",
         },
       ],
       "name": "Role",
@@ -10470,11 +10519,13 @@ exports[`getSchema parse test.prisma 1`] = `
     {
       "enumerators": [
         {
+          "attributes": undefined,
           "comment": undefined,
           "name": "USER",
           "type": "enumerator",
         },
         {
+          "attributes": undefined,
           "comment": undefined,
           "name": "ADMIN",
           "type": "enumerator",
@@ -10516,21 +10567,25 @@ exports[`getSchema parse unsorted.prisma 1`] = `
     {
       "enumerators": [
         {
+          "attributes": undefined,
           "comment": undefined,
           "name": "ADMIN",
           "type": "enumerator",
         },
         {
+          "attributes": undefined,
           "comment": "// similar to ADMIN, but can delete the project",
           "name": "OWNER",
           "type": "enumerator",
         },
         {
+          "attributes": undefined,
           "comment": undefined,
           "name": "MEMBER",
           "type": "enumerator",
         },
         {
+          "attributes": undefined,
           "comment": "// deprecated",
           "name": "USER",
           "type": "enumerator",

--- a/test/__snapshots__/printSchema.test.ts.snap
+++ b/test/__snapshots__/printSchema.test.ts.snap
@@ -680,8 +680,10 @@ model Model {
 }
 
 enum Role {
-  USER // basic role
-  ADMIN // more powerful role
+  USER @map("usr") // basic role
+  ADMIN @map("adm") // more powerful role
+
+  @@map("roles")
 }
 
 model Indexed {

--- a/test/fixtures/example.prisma
+++ b/test/fixtures/example.prisma
@@ -55,8 +55,10 @@ model Model {
 }
 
 enum Role {
-  USER // basic role
-  ADMIN // more powerful role
+  USER @map("usr") // basic role
+  ADMIN @map("adm") // more powerful role
+
+  @@map("roles")
 }
 
 model Indexed {


### PR DESCRIPTION
Updated parsing logic to allow for attributes on enum fields and `PrismaSchemaBuilder` can add attributes to enums. Includes `@@map('foo')` block attributes as well

Resolves #41 