### PR TITLE
fix(PrismaSchemaBuilder): datasource provider not out as string literal.

### DIFF
--- a/src/PrismaSchemaBuilder.ts
+++ b/src/PrismaSchemaBuilder.ts
@@ -166,7 +166,7 @@ export class ConcretePrismaSchemaBuilder {
               ? `"${url}"`
               : { type: 'function', name: 'env', params: [`"${url.env}"`] },
         },
-        { type: 'assignment', key: 'provider', value: provider },
+        { type: 'assignment', key: 'provider', value: `"${provider}"` },
       ],
     };
     const existingIndex = this.schema.list.findIndex(

--- a/test/PrismaSchemaBuilder.test.ts
+++ b/test/PrismaSchemaBuilder.test.ts
@@ -57,7 +57,7 @@ describe('PrismaSchemaBuilder', () => {
       "
       datasource db {
         url      = env("DATABASE_URL")
-        provider = postgresql
+        provider = "postgresql"
       }
       "
     `);
@@ -74,7 +74,7 @@ describe('PrismaSchemaBuilder', () => {
       "
       datasource my-database {
         url      = env("DATABASE_URL")
-        provider = postgresql
+        provider = "postgresql"
       }
       "
     `);
@@ -90,7 +90,7 @@ describe('PrismaSchemaBuilder', () => {
       "
       datasource db {
         url      = "https://database.com"
-        provider = postgresql
+        provider = "postgresql"
       }
       "
     `);

--- a/test/produceSchema.test.ts
+++ b/test/produceSchema.test.ts
@@ -32,7 +32,7 @@ describe('produceSchema', () => {
 
       datasource db {
         url      = env("DATABASE_URL")
-        provider = postgresql
+        provider = "postgresql"
       }
 
       model AppSetting {


### PR DESCRIPTION
Hey 👋 

Thanks for this awesome library! 🫶 

When using it to replace a `datasource` block in a PSL string, I found that it outputs `postgresql` instead of `"postgresql"` as the `provider` - which fails once you pass the new schema string to a Prisma ORM engine. Had to manually wrap in quotes as a workaround on my end.

Looks like values are wrapped with quotes in other places, so feels like a bug.