### PR TITLE
fix: fix params type

### DIFF
--- a/src/getSchema.ts
+++ b/src/getSchema.ts
@@ -169,7 +169,7 @@ export interface KeyValue {
 export interface Func {
   type: 'function';
   name: string;
-  params: Value[];
+  params?: Value[];
 }
 
 export interface RelationArray {


### PR DESCRIPTION
## Changes

I think the type for `Func → params` field is not quite correct. According to the test cases, it should be allowed to be undefined. 