### PR TITLE
Add partial index where clause support

### DIFF
--- a/src/PrismaSchemaBuilder.ts
+++ b/src/PrismaSchemaBuilder.ts
@@ -99,6 +99,19 @@ type Arg =
       name: string;
       function?: Arg[];
     };
+interface BuilderValueObject {
+  [key: string]: BuilderValue;
+}
+type BuilderValue =
+  | string
+  | number
+  | boolean
+  | null
+  | schema.Func
+  | schema.RelationArray
+  | schema.ObjectValue
+  | BuilderValue[]
+  | BuilderValueObject;
 type Parent = schema.Block | undefined;
 type Subject = schema.Block | schema.Field | schema.Enumerator | undefined;
 
@@ -279,7 +292,8 @@ export class ConcretePrismaSchemaBuilder {
    * */
   blockAttribute(
     name: string,
-    args?: string | string[] | Record<string, schema.Value>
+    args?: string | BuilderValue[] | Record<string, BuilderValue>,
+    params: Record<string, BuilderValue> = {}
   ): this {
     let subject = this.getSubject<schema.Object | schema.Enum>();
     if (subject.type !== 'enum' && !isSchemaObject(subject)) {
@@ -291,15 +305,34 @@ export class ConcretePrismaSchemaBuilder {
     }
 
     const attributeArgs = ((): schema.AttributeArgument[] => {
-      if (!args) return [] as schema.AttributeArgument[];
-      if (typeof args === 'string')
-        return [{ type: 'attributeArgument', value: `"${args}"` }];
-      if (Array.isArray(args))
-        return [{ type: 'attributeArgument', value: { type: 'array', args } }];
-      return Object.entries(args).map(([key, value]) => ({
-        type: 'attributeArgument',
-        value: { type: 'keyValue', key, value },
-      }));
+      const attributeArgs: schema.AttributeArgument[] = [];
+      const keyedArgs =
+        args && !Array.isArray(args) && typeof args === 'object'
+          ? { ...args, ...params }
+          : params;
+
+      if (typeof args === 'string') {
+        attributeArgs.push({
+          type: 'attributeArgument',
+          value: `"${args}"`,
+        });
+      } else if (Array.isArray(args)) {
+        attributeArgs.push({
+          type: 'attributeArgument',
+          value: { type: 'array', args: args.map((arg) => this.toValue(arg)) },
+        });
+      }
+
+      attributeArgs.push(
+        ...Object.entries(keyedArgs).map<schema.AttributeArgument>(
+          ([key, value]) => ({
+            type: 'attributeArgument',
+            value: { type: 'keyValue', key, value: this.toValue(value) },
+          })
+        )
+      );
+
+      return attributeArgs;
     })();
 
     const property: schema.BlockAttribute = {
@@ -320,7 +353,7 @@ export class ConcretePrismaSchemaBuilder {
   /** Adds an attribute to the current field. */
   attribute<T extends schema.Field>(
     name: string,
-    args?: Arg[] | Record<string, string[]>
+    args?: Arg[] | Record<string, BuilderValue>
   ): this {
     const parent = this.getParent();
     const subject = this.getSubject<T>();
@@ -347,32 +380,64 @@ export class ConcretePrismaSchemaBuilder {
     );
 
     if (Array.isArray(args)) {
-      const mapArg = (arg: Arg): schema.Value | schema.Func => {
-        return typeof arg === 'string'
-          ? arg
-          : {
-              type: 'function',
-              name: arg.name,
-              params: arg.function?.map(mapArg) ?? [],
-            };
-      };
-
       if (args.length > 0)
         attribute.args = args.map((arg) => ({
           type: 'attributeArgument',
-          value: mapArg(arg),
+          value: this.mapArg(arg),
         }));
     } else if (typeof args === 'object') {
-      attribute.args = Object.entries(args).map(([key, value]) => ({
-        type: 'attributeArgument',
-        value: { type: 'keyValue', key, value: { type: 'array', args: value } },
-      }));
+      attribute.args = Object.entries(args).map<schema.AttributeArgument>(
+        ([key, value]) => ({
+          type: 'attributeArgument',
+          value: { type: 'keyValue', key, value: this.toValue(value) },
+        })
+      );
     }
 
     if (!subject.attributes.includes(attribute))
       subject.attributes.push(attribute);
 
     return this;
+  }
+
+  private mapArg(arg: Arg): schema.Value | schema.Func {
+    return typeof arg === 'string'
+      ? arg
+      : {
+          type: 'function',
+          name: arg.name,
+          params: arg.function?.map((item) => this.mapArg(item)) ?? [],
+        };
+  }
+
+  private toValue(value: BuilderValue): schema.Value {
+    if (Array.isArray(value)) {
+      return {
+        type: 'array',
+        args: value.map((item) => this.toValue(item)),
+      };
+    }
+
+    if (value === null || typeof value !== 'object') {
+      return value;
+    }
+
+    if (
+      'type' in value &&
+      typeof value.type === 'string' &&
+      ['array', 'function', 'object'].includes(value.type)
+    ) {
+      return value as schema.Func | schema.RelationArray | schema.ObjectValue;
+    }
+
+    return {
+      type: 'object',
+      properties: Object.entries(value).map(([key, item]) => ({
+        type: 'keyValue',
+        key,
+        value: this.toValue(item),
+      })),
+    };
   }
 
   /** Remove an attribute from the current field */

--- a/src/getSchema.ts
+++ b/src/getSchema.ts
@@ -174,13 +174,20 @@ export interface Func {
 
 export interface RelationArray {
   type: 'array';
-  args: string[];
+  args: Value[];
+}
+
+export interface ObjectValue {
+  type: 'object';
+  properties: KeyValue[];
 }
 
 export type Value =
   | string
   | number
   | boolean
+  | null
   | Func
   | RelationArray
+  | ObjectValue
   | Array<Value>;

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -1,38 +1,8 @@
-import { createToken, Lexer, IMultiModeLexerDefinition } from 'chevrotain';
+import { createToken, Lexer } from 'chevrotain';
 
 export const Identifier = createToken({
   name: 'Identifier',
   pattern: /[a-zA-Z][\w-]*/,
-});
-export const Datasource = createToken({
-  name: 'Datasource',
-  pattern: /datasource/,
-  push_mode: 'block',
-});
-export const Generator = createToken({
-  name: 'Generator',
-  pattern: /generator/,
-  push_mode: 'block',
-});
-export const Model = createToken({
-  name: 'Model',
-  pattern: /model/,
-  push_mode: 'block',
-});
-export const View = createToken({
-  name: 'View',
-  pattern: /view/,
-  push_mode: 'block',
-});
-export const Enum = createToken({
-  name: 'Enum',
-  pattern: /enum/,
-  push_mode: 'block',
-});
-export const Type = createToken({
-  name: 'Type',
-  pattern: /type/,
-  push_mode: 'block',
 });
 export const True = createToken({
   name: 'True',
@@ -99,7 +69,6 @@ export const RCurly = createToken({
   name: 'RCurly',
   pattern: /}/,
   label: "'}'",
-  pop_mode: true,
 });
 export const LRound = createToken({
   name: 'LRound',
@@ -156,36 +125,32 @@ export const LineBreak = createToken({
   label: 'LineBreak',
 });
 
-const naTokens = [Comment, DocComment, LineComment, LineBreak, WhiteSpace];
+export const tokens = [
+  Comment,
+  DocComment,
+  LineComment,
+  LineBreak,
+  WhiteSpace,
+  Attribute,
+  BlockAttribute,
+  FieldAttribute,
+  Dot,
+  QuestionMark,
+  LCurly,
+  RCurly,
+  LSquare,
+  RSquare,
+  LRound,
+  RRound,
+  Comma,
+  Colon,
+  Equals,
+  True,
+  False,
+  Null,
+  StringLiteral,
+  NumberLiteral,
+  Identifier,
+];
 
-export const multiModeTokens: IMultiModeLexerDefinition = {
-  modes: {
-    global: [...naTokens, Datasource, Generator, Model, View, Enum, Type],
-    block: [
-      ...naTokens,
-      Attribute,
-      BlockAttribute,
-      FieldAttribute,
-      Dot,
-      QuestionMark,
-      LCurly,
-      RCurly,
-      LSquare,
-      RSquare,
-      LRound,
-      RRound,
-      Comma,
-      Colon,
-      Equals,
-      True,
-      False,
-      Null,
-      StringLiteral,
-      NumberLiteral,
-      Identifier,
-    ],
-  },
-  defaultMode: 'global',
-};
-
-export const PrismaLexer = new Lexer(multiModeTokens);
+export const PrismaLexer = new Lexer(tokens);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -13,7 +13,7 @@ export class PrismaParser extends CstParser {
   readonly config: PrismaAstParserConfig;
 
   constructor(config: PrismaAstParserConfig) {
-    super(lexer.multiModeTokens, config);
+    super(lexer.tokens, config);
     this.performSelfAnalysis();
     this.config = config;
   }
@@ -40,6 +40,17 @@ export class PrismaParser extends CstParser {
     this.CONSUME(lexer.RSquare);
   });
 
+  private object = this.RULE('object', () => {
+    this.CONSUME(lexer.LCurly);
+    this.MANY_SEP({
+      SEP: lexer.Comma,
+      DEF: () => {
+        this.SUBRULE(this.keyedArg);
+      },
+    });
+    this.CONSUME(lexer.RCurly);
+  });
+
   private func = this.RULE('func', () => {
     this.CONSUME(lexer.Identifier, { LABEL: 'funcName' });
     this.CONSUME(lexer.LRound);
@@ -60,6 +71,7 @@ export class PrismaParser extends CstParser {
       { ALT: () => this.CONSUME(lexer.StringLiteral, { LABEL: 'value' }) },
       { ALT: () => this.CONSUME(lexer.NumberLiteral, { LABEL: 'value' }) },
       { ALT: () => this.SUBRULE(this.array, { LABEL: 'value' }) },
+      { ALT: () => this.SUBRULE(this.object, { LABEL: 'value' }) },
       { ALT: () => this.SUBRULE(this.func, { LABEL: 'value' }) },
       { ALT: () => this.CONSUME(lexer.True, { LABEL: 'value' }) },
       { ALT: () => this.CONSUME(lexer.False, { LABEL: 'value' }) },
@@ -222,24 +234,17 @@ export class PrismaParser extends CstParser {
   });
 
   private component = this.RULE('component', () => {
-    const type = this.OR1([
-      { ALT: () => this.CONSUME(lexer.Datasource, { LABEL: 'type' }) },
-      { ALT: () => this.CONSUME(lexer.Generator, { LABEL: 'type' }) },
-      { ALT: () => this.CONSUME(lexer.Model, { LABEL: 'type' }) },
-      { ALT: () => this.CONSUME(lexer.View, { LABEL: 'type' }) },
-      { ALT: () => this.CONSUME(lexer.Enum, { LABEL: 'type' }) },
-      { ALT: () => this.CONSUME(lexer.Type, { LABEL: 'type' }) },
-    ]);
+    const type = this.CONSUME1(lexer.Identifier, { LABEL: 'type' });
     this.OR2([
       {
         ALT: () => {
-          this.CONSUME1(lexer.Identifier, { LABEL: 'groupName' });
+          this.CONSUME2(lexer.Identifier, { LABEL: 'groupName' });
           this.CONSUME(lexer.Dot);
-          this.CONSUME2(lexer.Identifier, { LABEL: 'componentName' });
+          this.CONSUME3(lexer.Identifier, { LABEL: 'componentName' });
         },
       },
       {
-        ALT: () => this.CONSUME(lexer.Identifier, { LABEL: 'componentName' }),
+        ALT: () => this.CONSUME4(lexer.Identifier, { LABEL: 'componentName' }),
       },
     ]);
 

--- a/src/printSchema.ts
+++ b/src/printSchema.ts
@@ -273,6 +273,7 @@ function printFunction(func: Types.Func) {
 function printValue(value: Types.KeyValue | Types.Value): string {
   switch (typeof value) {
     case 'object': {
+      if (value == null) return 'null';
       if ('type' in value) {
         switch (value.type) {
           case 'keyValue':
@@ -283,6 +284,10 @@ function printValue(value: Types.KeyValue | Types.Value): string {
             return `[${
               value.args != null ? value.args.map(printValue).join(', ') : ''
             }]`;
+          case 'object':
+            return value.properties.length > 0
+              ? `{ ${value.properties.map(printValue).join(', ')} }`
+              : '{}';
           default:
             throw new Error(`Unexpected value type`);
         }

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -229,6 +229,11 @@ export const VisitorClassFactory = (
       return { type: 'array', args };
     }
 
+    object(ctx: CstNode & { keyedArg: CstNode[] }): Types.ObjectValue {
+      const properties = ctx.keyedArg?.map((item) => this.visit([item])) ?? [];
+      return { type: 'object', properties };
+    }
+
     keyedArg(
       ctx: CstNode & { keyName: [IToken]; value: [CstNode] }
     ): Types.KeyValue {

--- a/test/PrismaSchemaBuilder.test.ts
+++ b/test/PrismaSchemaBuilder.test.ts
@@ -477,6 +477,47 @@ describe('PrismaSchemaBuilder', () => {
     `);
   });
 
+  it('adds a partial index attribute', () => {
+    const builder = createPrismaSchemaBuilder();
+    builder
+      .model('Post')
+      .field('slug', 'String')
+      .blockAttribute('index', ['slug'], {
+        where: {
+          published: true,
+          deletedAt: { not: null },
+        },
+      });
+    expect(builder.print()).toMatchInlineSnapshot(`
+      "
+      model Post {
+        slug String
+
+        @@index([slug], where: { published: true, deletedAt: { not: null } })
+      }
+      "
+    `);
+  });
+
+  it('adds a field-level partial unique attribute', () => {
+    const builder = createPrismaSchemaBuilder();
+    builder
+      .model('User')
+      .field('email', 'String')
+      .attribute('unique', {
+        where: {
+          deletedAt: null,
+        },
+      });
+    expect(builder.print()).toMatchInlineSnapshot(`
+      "
+      model User {
+        email String @unique(where: { deletedAt: null })
+      }
+      "
+    `);
+  });
+
   it('adds a comment', () => {
     const builder = createPrismaSchemaBuilder();
     builder

--- a/test/PrismaSchemaBuilder.test.ts
+++ b/test/PrismaSchemaBuilder.test.ts
@@ -518,6 +518,29 @@ describe('PrismaSchemaBuilder', () => {
     `);
   });
 
+  it('adds a partial index attribute with a raw where clause', () => {
+    const builder = createPrismaSchemaBuilder();
+    builder
+      .model('Post')
+      .field('slug', 'String')
+      .blockAttribute('index', ['slug'], {
+        where: {
+          type: 'function',
+          name: 'raw',
+          params: ['"published = true"'],
+        },
+      });
+    expect(builder.print()).toMatchInlineSnapshot(`
+      "
+      model Post {
+        slug String
+
+        @@index([slug], where: raw("published = true"))
+      }
+      "
+    `);
+  });
+
   it('adds a comment', () => {
     const builder = createPrismaSchemaBuilder();
     builder

--- a/test/getSchema.test.ts
+++ b/test/getSchema.test.ts
@@ -179,6 +179,51 @@ describe('getSchema', () => {
     });
   });
 
+  it('parses partial index raw where clauses', () => {
+    const schema = getSchema(`
+      model Post {
+        slug String
+
+        @@index([slug], where: raw("published = true"))
+      }
+    `);
+
+    const [model] = schema.list;
+    expect(model).toMatchObject({
+      type: 'model',
+      name: 'Post',
+    });
+
+    if (model.type !== 'model') fail();
+
+    const index = model.properties.find(
+      (property) => property.type === 'attribute' && property.name === 'index'
+    );
+
+    expect(index).toMatchObject({
+      type: 'attribute',
+      name: 'index',
+      args: [
+        {
+          type: 'attributeArgument',
+          value: { type: 'array', args: ['slug'] },
+        },
+        {
+          type: 'attributeArgument',
+          value: {
+            type: 'keyValue',
+            key: 'where',
+            value: {
+              type: 'function',
+              name: 'raw',
+              params: ['"published = true"'],
+            },
+          },
+        },
+      ],
+    });
+  });
+
   describe('with location tracking', () => {
     describe('passed-in parser and visitor', () => {
       it('contains field location info', async () => {

--- a/test/getSchema.test.ts
+++ b/test/getSchema.test.ts
@@ -123,6 +123,62 @@ describe('getSchema', () => {
     fail();
   });
 
+  it('parses partial index where objects', () => {
+    const schema = getSchema(`
+      model Post {
+        slug String
+
+        @@index([slug], where: { published: true, deletedAt: { not: null } })
+      }
+    `);
+
+    const [model] = schema.list;
+    expect(model).toMatchObject({
+      type: 'model',
+      name: 'Post',
+    });
+
+    if (model.type !== 'model') fail();
+
+    const index = model.properties.find(
+      (property) => property.type === 'attribute' && property.name === 'index'
+    );
+
+    expect(index).toMatchObject({
+      type: 'attribute',
+      name: 'index',
+      args: [
+        {
+          type: 'attributeArgument',
+          value: { type: 'array', args: ['slug'] },
+        },
+        {
+          type: 'attributeArgument',
+          value: {
+            type: 'keyValue',
+            key: 'where',
+            value: {
+              type: 'object',
+              properties: [
+                { type: 'keyValue', key: 'published', value: 'true' },
+                {
+                  type: 'keyValue',
+                  key: 'deletedAt',
+                  value: {
+                    type: 'object',
+                    properties: [
+                      { type: 'keyValue', key: 'not', value: 'null' },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    });
+  });
+
   describe('with location tracking', () => {
     describe('passed-in parser and visitor', () => {
       it('contains field location info', async () => {

--- a/test/printSchema.test.ts
+++ b/test/printSchema.test.ts
@@ -135,4 +135,24 @@ model Foo {
       "
     `);
   });
+
+  it('prints partial index raw where clauses', () => {
+    const schema = getSchema(`
+      model Post {
+        slug String
+
+        @@index([slug], where: raw("published = true"))
+      }
+    `);
+
+    expect(printSchema(schema)).toMatchInlineSnapshot(`
+      "
+      model Post {
+        slug String
+
+        @@index([slug], where: raw("published = true"))
+      }
+      "
+    `);
+  });
 });

--- a/test/printSchema.test.ts
+++ b/test/printSchema.test.ts
@@ -115,4 +115,24 @@ model Foo {
     expect(schema).not.toBeUndefined();
     expect(result).toEqual(expected.replace(/\r\n/g, '\n'));
   });
+
+  it('prints partial index where objects', () => {
+    const schema = getSchema(`
+      model Post {
+        slug String
+
+        @@index([slug], where: { published: true, deletedAt: { not: null } })
+      }
+    `);
+
+    expect(printSchema(schema)).toMatchInlineSnapshot(`
+      "
+      model Post {
+        slug String
+
+        @@index([slug], where: { published: true, deletedAt: { not: null } })
+      }
+      "
+    `);
+  });
 });

--- a/test/produceSchema.test.ts
+++ b/test/produceSchema.test.ts
@@ -54,4 +54,28 @@ describe('produceSchema', () => {
       "
     `);
   });
+
+  it('prints partial index where clauses', () => {
+    const result = produceSchema('', (builder) => {
+      builder
+        .model('Post')
+        .field('slug', 'String')
+        .blockAttribute('index', ['slug'], {
+          where: {
+            published: true,
+            deletedAt: { not: null },
+          },
+        });
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      "
+      model Post {
+        slug String
+
+        @@index([slug], where: { published: true, deletedAt: { not: null } })
+      }
+      "
+    `);
+  });
 });

--- a/test/produceSchema.test.ts
+++ b/test/produceSchema.test.ts
@@ -78,4 +78,29 @@ describe('produceSchema', () => {
       "
     `);
   });
+
+  it('prints partial index raw where clauses', () => {
+    const result = produceSchema('', (builder) => {
+      builder
+        .model('Post')
+        .field('slug', 'String')
+        .blockAttribute('index', ['slug'], {
+          where: {
+            type: 'function',
+            name: 'raw',
+            params: ['"published = true"'],
+          },
+        });
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      "
+      model Post {
+        slug String
+
+        @@index([slug], where: raw("published = true"))
+      }
+      "
+    `);
+  });
 });


### PR DESCRIPTION
Prisma 7.4 introduced the [`partialIndexes`](https://www.prisma.io/docs/orm/prisma-schema/data-model/indexes#configuring-partial-indexes-with-where) preview feature which supports a "where" clause in indexes in the schema file. This PR updates prisma-ast to support parsing index definitions that contain a "where" clause, both with the object syntax and raw queries.

The lexer changes are to allow the object syntax within the index definition. Each of the keywords is now tokenized as an `Identifier` which the parser can handle generically instead of special casing the specific keywords.

Tests are included, and I also manually tested on our schema file that makes use of partial indexes and verified it parses and prints correctly.